### PR TITLE
New feature: Automatic smoothing + Bug fixes

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -15,6 +15,7 @@ dependencies:
 - pandas
 - jinja2
 - pandoc
+- aplpy
 - pip:
   - casatasks
   - requests

--- a/frocc/.frocc_default_config.template
+++ b/frocc/.frocc_default_config.template
@@ -296,7 +296,7 @@ apiUrl = "https://idia-api.lennartheino.de/v1/upload"
 envVarApikey = 'MEERKAT_POL_APIKEY'
 
 commandCasa5 = "casa --nogui --log2term -c "
-commandPandoc = "pandoc --latex-engine=xelatex --highlight-style=tango -o "
+commandPandoc = "pandoc --pdf-engine=xelatex --highlight-style=tango -o "
 extShortListobs = ".short-listobs.txt"
 extReportMD = ".report.md"
 extReportPdf = ".report.pdf"

--- a/frocc/cube_buildcube.py
+++ b/frocc/cube_buildcube.py
@@ -87,11 +87,14 @@ def smoother(fitsnames, conf):
         common_beam = beams.common_beam()
         major = f"{np.ceil(common_beam.major.to(units.arcsec).value)}arcsec"
         minor = f"{np.ceil(common_beam.minor.to(units.arcsec).value)}arcsec"
+        pa = f"{np.ceil(common_beam.pa.to(units.deg).value)}deg"
     elif conf.input.smoothbeam.find(",") > 0:
         major, minor = conf.input.smoothbeam.split(",")
+        pa = "0deg"
     else:
         major = conf.input.smoothbeam
         minor = conf.input.smoothbeam
+        pa = "0deg"
     
     outSmoothedFitsNames = []
     for fitsname in fitsnames:
@@ -113,7 +116,7 @@ def smoother(fitsnames, conf):
             kernel="gauss",
             major=major,
             minor=minor,
-            pa="0deg",
+            pa=pa,
             overwrite=True,
         )
         info(f"Exporting: {outSmoothedFits}")

--- a/frocc/cube_buildcube.py
+++ b/frocc/cube_buildcube.py
@@ -75,7 +75,7 @@ def smoother(fitsnames, conf):
         beam_list = []
         for fitsname in fitsnames:
             header = fits.getheader(fitsname)
-            beam = Beam.from_fits.header(header)
+            beam = Beam.from_fits_header(header)
             beam_list.append(beam)
         beams = Beams(
             major=np.array([b.major.to(units.deg).value for b in beam_list])
@@ -85,8 +85,8 @@ def smoother(fitsnames, conf):
             pa=np.array([b.pa.to(units.deg).value for b in beam_list]) * units.deg,
         )
         common_beam = beams.common_beam()
-        major = f"{common_beam.major.to(units.arcsec).value}arcsec"
-        minor = f"{common_beam.minor.to(units.arcsec).value}arcsec"
+        major = f"{np.ceil(common_beam.major.to(units.arcsec).value)}arcsec"
+        minor = f"{np.ceil(common_beam.minor.to(units.arcsec).value)}arcsec"
     elif conf.input.smoothbeam.find(",") > 0:
         major, minor = conf.input.smoothbeam.split(",")
     else:
@@ -101,7 +101,9 @@ def smoother(fitsnames, conf):
 
         info(f"Importing: {fitsname}")
         casatasks.importfits(
-            fitsimage=fitsname, imagename=outImageName,
+            fitsimage=fitsname, 
+            imagename=outImageName,
+            overwrite=True,
         )
 
         casatasks.imsmooth(
@@ -213,10 +215,10 @@ def make_empty_image(conf, mode="normal"):
 
     """
     if mode == "smoothed":
-        oldChannelFitsfileList = sorted(glob(conf.env.dirImages + "*image.fits"))
+        oldChannelFitsfileList = sorted(glob(conf.env.dirImages + "*.chan*image.fits"))
         channelFitsfileList = smoother(oldChannelFitsfileList, conf)
     else:
-        channelFitsfileList = sorted(glob(conf.env.dirImages + "*image.fits"))
+        channelFitsfileList = sorted(glob(conf.env.dirImages + "*.chan*image.fits"))
         
     lowestChannelFitsfile = channelFitsfileList[0]
     highestChannelFitsfile = channelFitsfileList[-1]

--- a/frocc/cube_report.py
+++ b/frocc/cube_report.py
@@ -34,7 +34,7 @@ import matplotlib.pyplot as plt
 #import seaborn as sns
 from astropy.io import fits
 import aplpy
-
+from casatasks import listobs
 
 from frocc.lhelpers import get_channelNumber_from_filename, get_config_in_dot_notation, get_std_via_mad, main_timer, change_channelNumber_from_filename,  SEPERATOR, get_lowest_channelNo_with_data_in_cube, update_fits_header_of_cube, DotMap, get_dict_from_click_args, calculate_channelFreq_from_header, read_file_as_string, write_file_from_string, get_timestamp, run_command_with_logging, get_dict_from_tabFile, get_lowest_channelIdx_and_freq_with_data_in_cube
 from frocc.check_output import print_output
@@ -197,8 +197,7 @@ def write_listobs_for_inputMS_and_get_filenames(conf):
         outFile = os.path.join(conf.env.dirReport, os.path.basename(os.path.splitext(inputMS)[0]) + conf.env.extShortListobs)
         filenameList.append(outFile)
         info(f"Writing file: {outFile}")
-        command = f"{conf.env.commandCasa5} \"listobs(vis='{inputMS}', listfile='{outFile}', overwrite=True, verbose=False)\""
-        run_command_with_logging(command)
+        _ = listobs(vis=inputMS, listfile=outFile, overwrite=True, verbose=False)
     return filenameList
 
 

--- a/frocc/cube_tclean.py
+++ b/frocc/cube_tclean.py
@@ -116,22 +116,6 @@ def call_tclean(channelInputMS, channelNumber, conf):
     info(f"Exporting: {outImageFits}")
     casatasks.exportfits(imagename=outImageName, fitsimage=outImageFits, overwrite=True)
 
-    # Also create an smoothed image if conf.input.smoothbeam is truthy
-    if conf.input.smoothbeam:
-        outSmoothedName = outImageName + ".smoothed"
-        outSmoothedFits = outSmoothedName + ".fits"
-        if conf.input.smoothbeam.find(",") > 0:
-            major, minor = conf.input.smoothbeam.split(",")
-        else:
-            major = conf.input.smoothbeam
-            minor = conf.input.smoothbeam
-        casatasks.imsmooth(imagename=outImageName, outfile=outSmoothedName, targetres=True,
-                kernel='gauss', major=major,
-                minor=minor, pa='0deg',
-                overwrite=True)
-        info(f"Exporting: {outSmoothedFits}")
-        casatasks.exportfits(imagename=outSmoothedName, fitsimage=outSmoothedFits, overwrite=True)
-
 
 def get_channelNumber_from_slurmArrayTaskId(slurmArrayTaskId, conf):
     '''


### PR DESCRIPTION
Adds the ability to automatically determine after imaging. This uses `radio_beam` to find the smallest common beam. To accomplish this, I've moved smoothing to the build_cube stage. This has the disadvantage of running in serial. We could perhaps spin this out into its own script to allow it to run using a job array for each channel.

I've also included a couple of bug-fixes - this mostly affects the report script. It now uses casatasks to sniff the MS, and fixes some pandoc commands.