### PR TITLE
wsclean

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,3 +138,4 @@ __pycache__/
 */plots/*
 */cube.*
 #*/.*
+.vscode/settings.json

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ number of slurm taks depending on the input ms spw coverage.
 
 The last step `frocc --start` submits the slurm files in a dependency
 chain. Caution: CASA does not always seem to report back its failure state in
-a correct way. Therefore, the slurm flag `--dependency=afterany:...` is
+a correct way. Therefore, the slurm flag `--dependency=afterok:...` is
 chosen, which starts the next job in the chain even if the previous one has
 failed.
 

--- a/README.md
+++ b/README.md
@@ -17,12 +17,12 @@ frocc Usage
 
 5. Canel slurm jobs
 -------------------
-merkat-pol --cancel
+`frocc --cancel`
 
 5. Further help
 ---------------
-merkat-pol --readme
-merkat-pol --help
+`frocc --readme`
+`frocc --help`
 
 frocc Readme
 ==================
@@ -38,11 +38,15 @@ frocc Readme
 2. `cd frocc`
 3. `pip install --user .`
 
+### Via conda:
+1. `git clone git@github.com:idia-astro/frocc.git`
+2. `cd frocc`
+3. `conda env create`
 
 2. Implementation
 -----------------
 
-`merkat-pol` takes input measurement set (ms) data and parameters to create
+`frocc` takes input measurement set (ms) data and parameters to create
 channelized data cube in Stokes IQUV.  
 First CASA `split` is run to split out visibilities from the input ms into
 visibilities of the aimed resolution in frequency. Then `tclean` runs on each

--- a/environment.yml
+++ b/environment.yml
@@ -4,6 +4,7 @@ channels:
 - pkgw-forge
 dependencies:
 - python=3.6
+- astropy
 - pip
 - numpy
 - scipy

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
 - conda-forge
 - pkgw-forge
 dependencies:
-- python=3.6
+- python=3.8
 - astropy
 - pip
 - numpy
@@ -14,6 +14,7 @@ dependencies:
 - click
 - pandas
 - jinja2
+- pandoc
 - pip:
   - casatasks
   - requests

--- a/environment.yml
+++ b/environment.yml
@@ -1,8 +1,6 @@
 name: frocc
 channels:
-- astropy
 - conda-forge
-- defaults
 - pkgw-forge
 dependencies:
 - python=3.6

--- a/environment.yml
+++ b/environment.yml
@@ -10,6 +10,7 @@ dependencies:
 - scipy
 - matplotlib
 - casa-tools
+- python-casacore
 - seaborn
 - click
 - pandas

--- a/environment.yml
+++ b/environment.yml
@@ -15,6 +15,7 @@ dependencies:
 - pandas
 - jinja2
 - pandoc
+- aplpy
 - pip:
   - casatasks
   - requests

--- a/environment.yml
+++ b/environment.yml
@@ -16,4 +16,5 @@ dependencies:
 - jinja2
 - pip:
   - casatasks
+  - requests
   - -rrequirements.txt

--- a/environment.yml
+++ b/environment.yml
@@ -9,8 +9,6 @@ dependencies:
 - numpy
 - scipy
 - matplotlib
-- casa-tools
-- python-casacore
 - seaborn
 - click
 - pandas
@@ -19,5 +17,7 @@ dependencies:
 - aplpy
 - pip:
   - casatasks
+  - casatools
+  - python-casacore
   - requests
   - -rrequirements.txt

--- a/frocc/.frocc_default_config.template
+++ b/frocc/.frocc_default_config.template
@@ -168,6 +168,59 @@ restoration = True
 restoringbeam = ""
 
 # =============================================================================
+# wsclean options
+# For detailed help, check the WSClean website: https://wsclean.readthedocs.io/ .
+
+# DESCRIPTION:
+# https://wsclean.readthedocs.io/
+# TYPE: int
+# EXAMPLE: 100
+nchan = 1
+
+# DESCRIPTION:
+# https://wsclean.readthedocs.io/
+# TYPE: bool
+join_polarizations = True
+
+# DESCRIPTION:
+# https://wsclean.readthedocs.io/
+# TYPE: bool
+join_channels = True
+
+# DESCRIPTION:
+# https://wsclean.readthedocs.io/
+# TYPE: bool
+squared_channel_joining = True
+
+# DESCRIPTION:
+# https://wsclean.readthedocs.io/
+# TYPE: int
+# EXAMPLE: 1
+automask = 3
+
+# DESCRIPTION:
+# https://wsclean.readthedocs.io/
+# TYPE: int
+# EXAMPLE: 1
+auto_threshold = 1
+
+# DESCRIPTION:
+# https://wsclean.readthedocs.io/
+# TYPE: bool
+use_wgridder = True
+
+# DESCRIPTION:
+# https://wsclean.readthedocs.io/
+# TYPE: bool
+log_time = True
+
+# DESCRIPTION:
+# https://wsclean.readthedocs.io/
+# TYPE: float
+# EXAMPLE: 99
+mem = 90
+
+# =============================================================================
 # imsmooth
 # https://casa.nrao.edu/docs/TaskRef/imsmooth-task.html
 
@@ -194,7 +247,9 @@ dirHdf5Output = ""
 # DESCRIPTION: Scripts to run. Also used for sbatch dependency, therefore list
 # order matters!
 # TYPE: list(str)
-runScripts = ["cube_split.py", "cube_tclean.py", "cube_buildcube.py", "cube_ior_flagging.py", "cube_average_map.py", "cube_report.py", "cube_cleanup.py"]
+# runScripts = ["cube_split.py", "cube_tclean.py", "cube_buildcube.py", "cube_ior_flagging.py", "cube_average_map.py", "cube_report.py", "cube_cleanup.py"]
+runScripts = ["cube_wsclean.py", "cube_buildcube.py", "cube_ior_flagging.py", "cube_average_map.py", "cube_report.py", "cube_cleanup.py"]
+
 
 # DESCRIPTION: Slurm sbatch defaults dictionary. Values like array, mem,
 # job-name, cpus-per-task may be overwritten by the pipline

--- a/frocc/.frocc_default_config.template
+++ b/frocc/.frocc_default_config.template
@@ -257,8 +257,8 @@ dirList = ["dirLogs", "dirImages", "dirVis", "dirPlots", "dirReport"]
 # string marker for channel files
 markerChannel = ".chan"
 
-
-prefixSingularity = "singularity exec /users/lennart/container/frocc.simg"
+prefixSingularity = ""
+#prefixSingularity = "singularity exec /users/lennart/container/frocc.simg"
 #prefixSingularity = "singularity exec /users/krishna/ceph/casa-stable-lennart.simg"
 
 # The container and headnode have different python3 paths, hence the python3 $HOME...

--- a/frocc/.frocc_default_config.template
+++ b/frocc/.frocc_default_config.template
@@ -241,6 +241,11 @@ multiscale = False
 # TYPE: float
 multiscale_scale_bias = 0.7
 
+# DESCRIPTION:
+# https://wsclean.readthedocs.io/
+# TYPE: int
+deconvolution_threads = 1
+
 # =============================================================================
 # imsmooth
 # https://casa.nrao.edu/docs/TaskRef/imsmooth-task.html

--- a/frocc/.frocc_default_config.template
+++ b/frocc/.frocc_default_config.template
@@ -224,7 +224,13 @@ mem = 90
 # https://wsclean.readthedocs.io/
 # TYPE: int
 # EXAMPLE: 1
-threads = 1
+threads = 0
+
+# DESCRIPTION:
+# https://wsclean.readthedocs.io/
+# TYPE: int
+# EXAMPLE: 1
+parallel_deconvolution = 0
 
 # DESCRIPTION:
 # https://wsclean.readthedocs.io/
@@ -241,10 +247,6 @@ multiscale = False
 # TYPE: float
 multiscale_scale_bias = 0.7
 
-# DESCRIPTION:
-# https://wsclean.readthedocs.io/
-# TYPE: int
-deconvolution_threads = 1
 
 # =============================================================================
 # imsmooth

--- a/frocc/.frocc_default_config.template
+++ b/frocc/.frocc_default_config.template
@@ -247,6 +247,10 @@ multiscale = False
 # TYPE: float
 multiscale_scale_bias = 0.7
 
+# DESCRIPTION:
+# https://wsclean.readthedocs.io/
+# TYPE: str
+temp_dir = ""
 
 # =============================================================================
 # imsmooth

--- a/frocc/.frocc_default_config.template
+++ b/frocc/.frocc_default_config.template
@@ -220,6 +220,12 @@ log_time = True
 # EXAMPLE: 99
 mem = 90
 
+# DESCRIPTION:
+# https://wsclean.readthedocs.io/
+# TYPE: int
+# EXAMPLE: 1
+threads = 1
+
 # =============================================================================
 # imsmooth
 # https://casa.nrao.edu/docs/TaskRef/imsmooth-task.html
@@ -230,6 +236,7 @@ mem = 90
 # will fail with "Unable to reach target resolution ..."
 # TYPE: string
 # EXAMPLE: "15arcsec" or "12arcsec,13arcsec" or empty string "" for no smoothing
+# or "auto" for automatic smoothing
 smoothbeam = ""
 
 

--- a/frocc/.frocc_default_config.template
+++ b/frocc/.frocc_default_config.template
@@ -358,7 +358,7 @@ apiUrl = "https://idia-api.lennartheino.de/v1/upload"
 envVarApikey = 'MEERKAT_POL_APIKEY'
 
 commandCasa5 = "casa --nogui --log2term -c "
-commandPandoc = "pandoc --latex-engine=xelatex --highlight-style=tango -o "
+commandPandoc = "pandoc --pdf-engine=xelatex --highlight-style=tango -o "
 extShortListobs = ".short-listobs.txt"
 extReportMD = ".report.md"
 extReportPdf = ".report.pdf"

--- a/frocc/.frocc_default_config.template
+++ b/frocc/.frocc_default_config.template
@@ -3,7 +3,7 @@
 # Default config template file
 # ----------------------------
 #
-# This file serves as config file for sane defaults for the MeerKAT MIGHTEE 
+# This file serves as config file for sane defaults for the MeerKAT MIGHTEE
 # polarisation pipeline. The values in this file should not be edited. Instead
 # every value can be overwritten in `frocc_default_config.txt` (after
 # creating it via `frocc --createConfig --inputMS <path to input.ms>`).
@@ -50,7 +50,7 @@ outputChanBandwidth = 3e6
 # EXAMPLE: 0 or "" for all observations
 observation = ""
 
-# DESCRIPTION: File for the XY-phase and polarisation angle corrections. 
+# DESCRIPTION: File for the XY-phase and polarisation angle corrections.
 # coefficient units must be given in [GHz]
 # TYPE: str (path to coefficient file)
 # EXAMPLE: "coefficients.txt" TODO give example of file format.
@@ -225,6 +225,21 @@ mem = 90
 # TYPE: int
 # EXAMPLE: 1
 threads = 1
+
+# DESCRIPTION:
+# https://wsclean.readthedocs.io/
+# TYPE: bool
+iuwt = False
+
+# DESCRIPTION:
+# https://wsclean.readthedocs.io/
+# TYPE: bool
+multiscale = False
+
+# DESCRIPTION:
+# https://wsclean.readthedocs.io/
+# TYPE: float
+multiscale_scale_bias = 0.7
 
 # =============================================================================
 # imsmooth

--- a/frocc/check_input.py
+++ b/frocc/check_input.py
@@ -103,7 +103,7 @@ README='''
  
  The last step `frocc --start` submits the slurm files in a dependency
  chain. Caution: CASA does not always seem to report back its failure state in
- a correct way. Therefore, the slurm flag `--dependency=afterany:...` is
+ a correct way. Therefore, the slurm flag `--dependency=afterok:...` is
  chosen, which starts the next job in the chain even if the previous one has
  failed.
  

--- a/frocc/cube_buildcube.py
+++ b/frocc/cube_buildcube.py
@@ -87,11 +87,14 @@ def smoother(fitsnames, conf):
         common_beam = beams.common_beam()
         major = f"{np.ceil(common_beam.major.to(units.arcsec).value)}arcsec"
         minor = f"{np.ceil(common_beam.minor.to(units.arcsec).value)}arcsec"
+        pa = f"{np.ceil(common_beam.pa.to(units.deg).value)}deg"
     elif conf.input.smoothbeam.find(",") > 0:
         major, minor = conf.input.smoothbeam.split(",")
+        pa = "0deg"
     else:
         major = conf.input.smoothbeam
         minor = conf.input.smoothbeam
+        pa = "0deg"
     
     outSmoothedFitsNames = []
     for fitsname in fitsnames:
@@ -113,7 +116,7 @@ def smoother(fitsnames, conf):
             kernel="gauss",
             major=major,
             minor=minor,
-            pa="0deg",
+            pa=pa,
             overwrite=True,
         )
         info(f"Exporting: {outSmoothedFits}")

--- a/frocc/cube_buildcube.py
+++ b/frocc/cube_buildcube.py
@@ -75,7 +75,7 @@ def smoother(fitsnames, conf):
         beam_list = []
         for fitsname in fitsnames:
             header = fits.getheader(fitsname)
-            beam = Beam.from_fits.header(header)
+            beam = Beam.from_fits_header(header)
             beam_list.append(beam)
         beams = Beams(
             major=np.array([b.major.to(units.deg).value for b in beam_list])
@@ -85,8 +85,8 @@ def smoother(fitsnames, conf):
             pa=np.array([b.pa.to(units.deg).value for b in beam_list]) * units.deg,
         )
         common_beam = beams.common_beam()
-        major = f"{common_beam.major.to(units.arcsec).value}arcsec"
-        minor = f"{common_beam.minor.to(units.arcsec).value}arcsec"
+        major = f"{np.ceil(common_beam.major.to(units.arcsec).value)}arcsec"
+        minor = f"{np.ceil(common_beam.minor.to(units.arcsec).value)}arcsec"
     elif conf.input.smoothbeam.find(",") > 0:
         major, minor = conf.input.smoothbeam.split(",")
     else:
@@ -101,7 +101,9 @@ def smoother(fitsnames, conf):
 
         info(f"Importing: {fitsname}")
         casatasks.importfits(
-            fitsimage=fitsname, imagename=outImageName,
+            fitsimage=fitsname, 
+            imagename=outImageName,
+            overwrite=True,
         )
 
         casatasks.imsmooth(
@@ -213,10 +215,10 @@ def make_empty_image(conf, mode="normal"):
 
     """
     if mode == "smoothed":
-        oldChannelFitsfileList = sorted(glob(conf.env.dirImages + "*image.fits"))
+        oldChannelFitsfileList = sorted(glob(conf.env.dirImages + "*.chan*image.fits"))
         channelFitsfileList = smoother(oldChannelFitsfileList, conf)
     else:
-        channelFitsfileList = sorted(glob(conf.env.dirImages + "*image.fits"))
+        channelFitsfileList = sorted(glob(conf.env.dirImages + "*.chan*image.fits"))
         
     lowestChannelFitsfile = channelFitsfileList[0]
     highestChannelFitsfile = channelFitsfileList[-1]

--- a/frocc/cube_report.py
+++ b/frocc/cube_report.py
@@ -34,7 +34,7 @@ import matplotlib.pyplot as plt
 #import seaborn as sns
 from astropy.io import fits
 import aplpy
-
+from casatasks import listobs
 
 from frocc.lhelpers import get_channelNumber_from_filename, get_config_in_dot_notation, get_std_via_mad, main_timer, change_channelNumber_from_filename,  SEPERATOR, get_lowest_channelNo_with_data_in_cube, update_fits_header_of_cube, DotMap, get_dict_from_click_args, calculate_channelFreq_from_header, read_file_as_string, write_file_from_string, get_timestamp, run_command_with_logging, get_dict_from_tabFile, get_lowest_channelIdx_and_freq_with_data_in_cube
 from frocc.check_output import print_output
@@ -197,8 +197,7 @@ def write_listobs_for_inputMS_and_get_filenames(conf):
         outFile = os.path.join(conf.env.dirReport, os.path.basename(os.path.splitext(inputMS)[0]) + conf.env.extShortListobs)
         filenameList.append(outFile)
         info(f"Writing file: {outFile}")
-        command = f"{conf.env.commandCasa5} \"listobs(vis='{inputMS}', listfile='{outFile}', overwrite=True, verbose=False)\""
-        run_command_with_logging(command)
+        _ = listobs(vis=inputMS, listfile=outFile, overwrite=True, verbose=False)
     return filenameList
 
 

--- a/frocc/cube_tclean.py
+++ b/frocc/cube_tclean.py
@@ -116,22 +116,6 @@ def call_tclean(channelInputMS, channelNumber, conf):
     info(f"Exporting: {outImageFits}")
     casatasks.exportfits(imagename=outImageName, fitsimage=outImageFits, overwrite=True)
 
-    # Also create an smoothed image if conf.input.smoothbeam is truthy
-    if conf.input.smoothbeam:
-        outSmoothedName = outImageName + ".smoothed"
-        outSmoothedFits = outSmoothedName + ".fits"
-        if conf.input.smoothbeam.find(",") > 0:
-            major, minor = conf.input.smoothbeam.split(",")
-        else:
-            major = conf.input.smoothbeam
-            minor = conf.input.smoothbeam
-        casatasks.imsmooth(imagename=outImageName, outfile=outSmoothedName, targetres=True,
-                kernel='gauss', major=major,
-                minor=minor, pa='0deg',
-                overwrite=True)
-        info(f"Exporting: {outSmoothedFits}")
-        casatasks.exportfits(imagename=outSmoothedName, fitsimage=outSmoothedFits, overwrite=True)
-
 
 def get_channelNumber_from_slurmArrayTaskId(slurmArrayTaskId, conf):
     '''

--- a/frocc/cube_wsclean.py
+++ b/frocc/cube_wsclean.py
@@ -806,6 +806,8 @@ def call_wsclean(inputMS, conf, use_mpi=False):
         mem=conf.input.mem,
         parallel_deconvolution=conf.input.imsize // int(np.floor(np.sqrt(conf.input.threads))),
         iuwt=conf.input.iuwt,
+        multiscale=conf.input.multiscale,
+        multiscale_scale_bias=conf.input.multiscale_scale_bias,
     )
     info(f"wsclean command: {command}")
     sp.run(command.split())

--- a/frocc/cube_wsclean.py
+++ b/frocc/cube_wsclean.py
@@ -245,474 +245,474 @@ def wsclean(
 ):
     """Construct a wsclean command.
 
-    If False or None is passed as a parameter, the parameter is not included 
+    If False or None is passed as a parameter, the parameter is not included
     in the command (i.e. wsclean will assume a default value).
 
     Args:
         mslist (list): List of MSs to be processed.
         use_mpi (bool): Use wsclean-mp for parallel processing.
-        version (bool, optional): Print WSClean's version and exit. 
+        version (bool, optional): Print WSClean's version and exit.
             Defaults to False.
-        j (int, optional): Specify number of computing threads to use, 
-            i.e., number of cpu cores that will be used. 
+        j (int, optional): Specify number of computing threads to use,
+            i.e., number of cpu cores that will be used.
             Default: use all cpu cores. to None.
-        parallel_gridding (int, optional): Will execute multiple gridders 
-            simultaneously. This can make things faster in certain cases, 
+        parallel_gridding (int, optional): Will execute multiple gridders
+            simultaneously. This can make things faster in certain cases,
             but will increase memory usage. Defaults to None.
-        parallel_reordering (int, optional): Process the reordering with 
+        parallel_reordering (int, optional): Process the reordering with
             multipliple threads. Defaults to None.
-        no_work_on_master (bool, optional): In MPI runs, do not use the master 
-            for gridding. This may be useful if the resources such as memory 
+        no_work_on_master (bool, optional): In MPI runs, do not use the master
+            for gridding. This may be useful if the resources such as memory
             of the master are limited. Defaults to False.
-        mem (float, optional): Limit memory usage to the given fraction of the 
-            total system memory. This is an approximate value. 
+        mem (float, optional): Limit memory usage to the given fraction of the
+            total system memory. This is an approximate value.
             Default: 100. Defaults to None.
-        abs_mem (float, optional): Like -mem, but this specifies a fixed amount 
+        abs_mem (float, optional): Like -mem, but this specifies a fixed amount
             of memory in gigabytes. Defaults to None.
-        verbose (bool, optional): Increase verbosity of output. 
+        verbose (bool, optional): Increase verbosity of output.
             Defaults to False.
-        log_time (bool, optional): Add date and time to each line in the 
+        log_time (bool, optional): Add date and time to each line in the
             output. Defaults to False.
-        quiet (bool, optional): Do not output anything but errors. 
+        quiet (bool, optional): Do not output anything but errors.
             Defaults to False.
-        reorder (bool, optional): Force reordering of Measurement Set. 
-            This can be faster when the measurement set needs to be iterated 
-            several times, such as with many major iterations or in channel 
-            imaging mode. Default: only reorder when in channel imaging mode. 
+        reorder (bool, optional): Force reordering of Measurement Set.
+            This can be faster when the measurement set needs to be iterated
+            several times, such as with many major iterations or in channel
+            imaging mode. Default: only reorder when in channel imaging mode.
             Defaults to False.
-        no_reorder (bool, optional): Disable reordering of Measurement Set. 
-            This can be faster when the measurement set needs to be iterated 
-            several times, such as with many major iterations or in channel 
-            imaging mode. Default: only reorder when in channel imaging mode. 
+        no_reorder (bool, optional): Disable reordering of Measurement Set.
+            This can be faster when the measurement set needs to be iterated
+            several times, such as with many major iterations or in channel
+            imaging mode. Default: only reorder when in channel imaging mode.
             Defaults to False.
-        temp_dir (str, optional): Set the temporary directory used when 
-            reordering files. Default: same directory as input measurement set. 
+        temp_dir (str, optional): Set the temporary directory used when
+            reordering files. Default: same directory as input measurement set.
             Defaults to None.
         update_model_required (bool, optional): Default. Defaults to False.
-        no_update_model_required (bool, optional): These two options specify 
-            whether the model data column is required to contain valid model 
-            data after imaging. It can save time to not update the model data 
+        no_update_model_required (bool, optional): These two options specify
+            whether the model data column is required to contain valid model
+            data after imaging. It can save time to not update the model data
             column. Defaults to False.
-        no_dirty (bool, optional): Do not save the dirty image. 
+        no_dirty (bool, optional): Do not save the dirty image.
             Defaults to False.
-        save_first_residual (bool, optional): Save the residual after the 
+        save_first_residual (bool, optional): Save the residual after the
             first iteration. Defaults to False.
-        save_weights (bool, optional): Save the gridded weights in the a fits 
+        save_weights (bool, optional): Save the gridded weights in the a fits
             file named <image-prefix>-weights.fits. Defaults to False.
-        save_uv (bool, optional): Save the gridded uv plane, i.e., the FFT of 
-            the residual image. The UV plane is complex, hence two images will 
-            be output: <prefix>-uv-real.fits and <prefix>-uv-imag.fits. 
+        save_uv (bool, optional): Save the gridded uv plane, i.e., the FFT of
+            the residual image. The UV plane is complex, hence two images will
+            be output: <prefix>-uv-real.fits and <prefix>-uv-imag.fits.
             Defaults to False.
-        reuse_psf (str, optional): Load the psf(s) from the given prefix and 
+        reuse_psf (str, optional): Load the psf(s) from the given prefix and
             skip the inversion for the psf image. Defaults to None.
-        reuse_dirty (str, optional): Load the dirty from the given prefix and 
+        reuse_dirty (str, optional): Load the dirty from the given prefix and
             skip the inversion for the dirty image. Defaults to None.
-        apply_primary_beam (bool, optional): Calculate and apply the primary 
-            beam and save images for the Jones components, with weighting 
-            identical to the weighting as used by the imager. Only available 
+        apply_primary_beam (bool, optional): Calculate and apply the primary
+            beam and save images for the Jones components, with weighting
+            identical to the weighting as used by the imager. Only available
             for instruments supported by EveryBeam. Defaults to False.
-        reuse_primary_beam (bool, optional): If a primary beam image exists 
+        reuse_primary_beam (bool, optional): If a primary beam image exists
             on disk, reuse those images. Defaults to False.
-        use_differential_lofar_beam (bool, optional): Assume the visibilities 
-            have already been beam-corrected for the reference direction. 
-            By default, WSClean will use the information in the measurement 
-            set to determine if the differential beam should be applied for 
+        use_differential_lofar_beam (bool, optional): Assume the visibilities
+            have already been beam-corrected for the reference direction.
+            By default, WSClean will use the information in the measurement
+            set to determine if the differential beam should be applied for
             obtaining proper flux levels. Defaults to False.
-        primary_beam_limit (float, optional): Level at which to trim the beam 
-            when performing image-based beam correction,. Default: 0.005. 
+        primary_beam_limit (float, optional): Level at which to trim the beam
+            when performing image-based beam correction,. Default: 0.005.
             Defaults to None.
-        mwa_path (str, optional): Set path where to find the MWA beam file(s). 
+        mwa_path (str, optional): Set path where to find the MWA beam file(s).
             Defaults to None.
-        save_psf_pb (bool, optional): When applying beam correction, 
+        save_psf_pb (bool, optional): When applying beam correction,
             also save the primary-beam corrected PSF image. Defaults to False.
-        pb_grid_size (int, optional): Specify the grid size in number of 
-            pixels at which to evaluate the primary beam. 
-            Typically, the primary beam is calculated at a coarse resolution 
-            grid and interpolated, to reduce the time spent in evaluating the 
-            beam. This parameter controls the resolution of the grid at which 
-            to evaluate the primary beam. For rectangular images, pb-grid-size 
-            indicates the number of pixels along the shortest dimension. 
-            The total number of pixels in the primary beam grid thus amounts 
-            to: 
-                max(width, height) / min(width, height) * pb-grid-size**2. 
+        pb_grid_size (int, optional): Specify the grid size in number of
+            pixels at which to evaluate the primary beam.
+            Typically, the primary beam is calculated at a coarse resolution
+            grid and interpolated, to reduce the time spent in evaluating the
+            beam. This parameter controls the resolution of the grid at which
+            to evaluate the primary beam. For rectangular images, pb-grid-size
+            indicates the number of pixels along the shortest dimension.
+            The total number of pixels in the primary beam grid thus amounts
+            to:
+                max(width, height) / min(width, height) * pb-grid-size**2.
             Default: 32. Defaults to None.
-        beam_model (str, optional): Specify the beam model, only relevant for 
-            SKA and LOFAR. Available models are Hamaker, Lobes, OskarDipole, 
-            OskarSphericalWave. Input is case insensitive. Default is Hamaker 
+        beam_model (str, optional): Specify the beam model, only relevant for
+            SKA and LOFAR. Available models are Hamaker, Lobes, OskarDipole,
+            OskarSphericalWave. Input is case insensitive. Default is Hamaker
             for LOFAR and OskarSphericalWave for SKA. Defaults to None.
-        beam_mode (str, optional): [DEBUGGING ONLY] Manually specify the 
-            beam mode. Only relevant for simulated SKA measurement sets. 
-            Available modes are array_factor, element and full. Input is case 
+        beam_mode (str, optional): [DEBUGGING ONLY] Manually specify the
+            beam mode. Only relevant for simulated SKA measurement sets.
+            Available modes are array_factor, element and full. Input is case
             insensitive. Default is full. Defaults to None.
-        beam_normalisation_mode (str, optional): [DEBUGGING ONLY] 
-            Manually specify the normalisation of the beam. Only relevant 
-            for simulated SKA measurement sets. Available modes are none, 
-            preapplied, full, and amplitude. Default is preapplied. 
+        beam_normalisation_mode (str, optional): [DEBUGGING ONLY]
+            Manually specify the normalisation of the beam. Only relevant
+            for simulated SKA measurement sets. Available modes are none,
+            preapplied, full, and amplitude. Default is preapplied.
             Defaults to None.
         dry_run (bool, optional): Parses the command line and quits afterwards.
             No imaging is done. Defaults to False.
-        weight (str, optional): Weightmode can be: natural, uniform, briggs. 
-            Default: uniform. When using Briggs' weighting, add the robustness 
+        weight (str, optional): Weightmode can be: natural, uniform, briggs.
+            Default: uniform. When using Briggs' weighting, add the robustness
             parameter, like: "-weight briggs 0.5". Defaults to None.
-        super_weight (float, optional): Increase the weight gridding box size, 
-            similar to Casa's superuniform weighting scheme. Default: 1.0 
-            The factor can be rational and can be less than one for subpixel 
+        super_weight (float, optional): Increase the weight gridding box size,
+            similar to Casa's superuniform weighting scheme. Default: 1.0
+            The factor can be rational and can be less than one for subpixel
             weighting. Defaults to None.
-        mf_weighting (bool, optional): In spectral mode, calculate the weights 
-            as if the image was made using MF. This makes sure that the sum of 
-            channel images equals the MF weights. Otherwise, the channel image 
-            will become a bit more naturally weighted. This is only relevant 
-            for weighting modes that require gridding (i.e., Uniform, Briggs'). 
-            Default: off, unless -join-channels is specified. 
+        mf_weighting (bool, optional): In spectral mode, calculate the weights
+            as if the image was made using MF. This makes sure that the sum of
+            channel images equals the MF weights. Otherwise, the channel image
+            will become a bit more naturally weighted. This is only relevant
+            for weighting modes that require gridding (i.e., Uniform, Briggs').
+            Default: off, unless -join-channels is specified.
             Defaults to False.
-        no_mf_weighting (bool, optional): Opposite of -ms-weighting; 
-            can be used to turn off MF weighting in -join-channels mode. 
+        no_mf_weighting (bool, optional): Opposite of -ms-weighting;
+            can be used to turn off MF weighting in -join-channels mode.
             Defaults to False.
-        weighting_rank_filter (float, optional): Filter the weights and set 
-            high weights to the local mean. The level parameter specifies the 
-            filter level; any value larger than level*localmean will be set to 
+        weighting_rank_filter (float, optional): Filter the weights and set
+            high weights to the local mean. The level parameter specifies the
+            filter level; any value larger than level*localmean will be set to
             level*localmean. Defaults to None.
-        weighting_rank_filter_size (float, optional): Set size of weighting 
+        weighting_rank_filter_size (float, optional): Set size of weighting
             rank filter. Default: 16. Defaults to None.
-        taper_gaussian (str, optional): Taper the weights with a Gaussian 
-            function. This will reduce the contribution of long baselines. 
-            The beamsize is by default in asec, but a unit can be specified 
+        taper_gaussian (str, optional): Taper the weights with a Gaussian
+            function. This will reduce the contribution of long baselines.
+            The beamsize is by default in asec, but a unit can be specified
             ("2amin"). Defaults to None.
-        taper_tukey (float, optional): Taper the outer weights with a Tukey 
-            transition. Lambda specifies the size of the transition; use in 
+        taper_tukey (float, optional): Taper the outer weights with a Tukey
+            transition. Lambda specifies the size of the transition; use in
             combination with -maxuv-l. Defaults to None.
-        taper_inner_tukey (float, optional): Taper the weights with a Tukey 
-            transition. Lambda specifies the size of the transition; use in 
+        taper_inner_tukey (float, optional): Taper the weights with a Tukey
+            transition. Lambda specifies the size of the transition; use in
             combination with -minuv-l. Defaults to None.
-        taper_edge (float, optional): Taper the weights with a rectangle, 
-            to keep a space of lambda between the edge and gridded 
+        taper_edge (float, optional): Taper the weights with a rectangle,
+            to keep a space of lambda between the edge and gridded
             visibilities. Defaults to None.
-        taper_edge_tukey (float, optional): Taper the edge weights with a Tukey 
-            window. Lambda is the size of the Tukey transition. When 
-            -taper-edge is also specified, the Tukey transition starts inside 
+        taper_edge_tukey (float, optional): Taper the edge weights with a Tukey
+            window. Lambda is the size of the Tukey transition. When
+            -taper-edge is also specified, the Tukey transition starts inside
             the inner rectangle. Defaults to None.
-        use_weights_as_taper (bool, optional): Will not use visibility weights 
-            when determining the imaging weights. This has the effect that e.g. 
-            uniform weighting can be modified by increasing the visibility 
-            weight of certain baselines. Without this option, uniform imaging 
-            weights absorb the visibility weight to make the weighting truly 
+        use_weights_as_taper (bool, optional): Will not use visibility weights
+            when determining the imaging weights. This has the effect that e.g.
+            uniform weighting can be modified by increasing the visibility
+            weight of certain baselines. Without this option, uniform imaging
+            weights absorb the visibility weight to make the weighting truly
             uniform. Defaults to False.
-        store_imaging_weights (bool, optional): Will store the imaging weights 
+        store_imaging_weights (bool, optional): Will store the imaging weights
             in a column named 'IMAGING_WEIGHT_SPECTRUM'. Defaults to False.
-        name (str, optional): Use image-prefix as prefix for output files. 
+        name (str, optional): Use image-prefix as prefix for output files.
             Default is 'wsclean'. Defaults to None.
-        size (str, optional): Set the output image size in number of pixels 
+        size (str, optional): Set the output image size in number of pixels
             (without padding). Defaults to None.
-        padding (float, optional): Pad images by the given factor during 
+        padding (float, optional): Pad images by the given factor during
             inversion to avoid aliasing. Default: 1.2 (=20%). Defaults to None.
-        scale (str, optional): Scale of a pixel. Default unit is degrees, but 
-            can be specificied, e.g. -scale 20asec. Default: 0.01deg. 
+        scale (str, optional): Scale of a pixel. Default unit is degrees, but
+            can be specificied, e.g. -scale 20asec. Default: 0.01deg.
             Defaults to None.
-        predict (bool, optional): Only perform a single prediction for an 
-            existing image. Doesn't do any imaging or cleaning. The input 
-            images should have the same name as the model output images would 
+        predict (bool, optional): Only perform a single prediction for an
+            existing image. Doesn't do any imaging or cleaning. The input
+            images should have the same name as the model output images would
             have in normal imaging mode. Defaults to False.
-        ws_continue (bool, optional): Will continue an earlier WSClean run. 
-            Earlier model images will be read and model visibilities will be 
-            subtracted to create the first dirty residual. CS should have been 
-            used in the earlier run, and model datashould have been written 
-            to the measurement set for this to work. Default: off. 
+        ws_continue (bool, optional): Will continue an earlier WSClean run.
+            Earlier model images will be read and model visibilities will be
+            subtracted to create the first dirty residual. CS should have been
+            used in the earlier run, and model datashould have been written
+            to the measurement set for this to work. Default: off.
             Defaults to False.
-        subtract_model (bool, optional): Subtract the model from the 
-            data column in the first iteration. This can be used to reimage 
-            an already cleaned image, e.g. at a different resolution. 
+        subtract_model (bool, optional): Subtract the model from the
+            data column in the first iteration. This can be used to reimage
+            an already cleaned image, e.g. at a different resolution.
             Defaults to False.
-        channels_out (int, optional): Splits the bandwidth and makes count 
+        channels_out (int, optional): Splits the bandwidth and makes count
             nr. of images. Default: 1. Defaults to None.
-        shift (str, optional): Shift the phase centre to the given location. 
+        shift (str, optional): Shift the phase centre to the given location.
             The shift is along the tangential plane. Defaults to None.
-        gap_channel_division (bool, optional): In case of irregular frequency 
-            spacing, this option can be used to not try and split channels to 
-            make the output channel bandwidth similar, but instead to split 
+        gap_channel_division (bool, optional): In case of irregular frequency
+            spacing, this option can be used to not try and split channels to
+            make the output channel bandwidth similar, but instead to split
             largest gaps first. Defaults to False.
-        channel_division_frequencies (str, optional): Split the bandwidth at 
-            the specified frequencies (in Hz) before the normal bandwidth 
-            division is performed. This can e.g. be useful for imaging multiple 
+        channel_division_frequencies (str, optional): Split the bandwidth at
+            the specified frequencies (in Hz) before the normal bandwidth
+            division is performed. This can e.g. be useful for imaging multiple
             bands with irregular number of channels. Defaults to None.
-        nwlayers (int, optional): Number of w-layers to use. Default: minimum 
+        nwlayers (int, optional): Number of w-layers to use. Default: minimum
             suggested #w-layers for first MS. Defaults to None.
-        nwlayers_factor (float, optional): Use automatic calculation of the 
-            number of w-layers, but multiple that number by the given factor. 
+        nwlayers_factor (float, optional): Use automatic calculation of the
+            number of w-layers, but multiple that number by the given factor.
             This can e.g. be useful for increasing w-accuracy. Defaults to None.
-        nwlayers_for_size (str, optional): Use the minimum suggested w-layers 
-            for an image of the given size. Can e.g. be used to increase 
-            accuracy when predicting small part of full image. 
+        nwlayers_for_size (str, optional): Use the minimum suggested w-layers
+            for an image of the given size. Can e.g. be used to increase
+            accuracy when predicting small part of full image.
             Defaults to None.
-        no_small_inversion (bool, optional): Perform inversion at the Nyquist 
-            resolution and upscale the image to the requested image size 
-            afterwards. This speeds up inversion considerably, but makes 
-            aliasing slightly worse. This effect is in most cases <1%. 
+        no_small_inversion (bool, optional): Perform inversion at the Nyquist
+            resolution and upscale the image to the requested image size
+            afterwards. This speeds up inversion considerably, but makes
+            aliasing slightly worse. This effect is in most cases <1%.
             Default: on. Defaults to False.
-        small_inversion (bool, optional): Perform inversion at the 
-            Nyquist resolution and upscale the image to the requested 
-            image size afterwards. This speeds up inversion considerably, 
-            but makes aliasing slightly worse. This effect is in most cases 
+        small_inversion (bool, optional): Perform inversion at the
+            Nyquist resolution and upscale the image to the requested
+            image size afterwards. This speeds up inversion considerably,
+            but makes aliasing slightly worse. This effect is in most cases
             <1%. Default: on. Defaults to False.
-        grid_mode (str, optional): Kernel and mode used for gridding: 
-            kb = Kaiser-Bessel (default with 7 pixels), nn = nearest neighbour 
-            (no kernel), more options: rect, kb-no-sinc, gaus, bn. Default: kb. 
+        grid_mode (str, optional): Kernel and mode used for gridding:
+            kb = Kaiser-Bessel (default with 7 pixels), nn = nearest neighbour
+            (no kernel), more options: rect, kb-no-sinc, gaus, bn. Default: kb.
             Defaults to None.
-        kernel_size (int, optional): Gridding antialiasing kernel size. 
+        kernel_size (int, optional): Gridding antialiasing kernel size.
             Default: 7. Defaults to None.
-        oversampling (int, optional): Oversampling factor used during gridding. 
+        oversampling (int, optional): Oversampling factor used during gridding.
             Default: 63. Defaults to None.
-        make_psf (bool, optional): Always make the psf, even when no cleaning 
+        make_psf (bool, optional): Always make the psf, even when no cleaning
             is performed. Defaults to False.
-        make_psf_only (bool, optional): Only make the psf, no images are made. 
+        make_psf_only (bool, optional): Only make the psf, no images are made.
             Defaults to False.
-        visibility_weighting_mode (str, optional): Specify visibility weighting 
-            modi. Affects how the weights (normally) stored in WEIGHT_SPECTRUM 
-            column are applied. Useful for estimating e.g. EoR power spectra 
-            errors. Normally one would use this in combination with 
+        visibility_weighting_mode (str, optional): Specify visibility weighting
+            modi. Affects how the weights (normally) stored in WEIGHT_SPECTRUM
+            column are applied. Useful for estimating e.g. EoR power spectra
+            errors. Normally one would use this in combination with
             -no-normalize-for-weighting. Defaults to None.
-        no_normalize_for_weighting (bool, optional): Disable the normalization 
-            for the weights, which makes the PSF's peak one. 
-            See -visibility-weighting-mode. Only useful with natural weighting. 
+        no_normalize_for_weighting (bool, optional): Disable the normalization
+            for the weights, which makes the PSF's peak one.
+            See -visibility-weighting-mode. Only useful with natural weighting.
             Defaults to False.
-        baseline_averaging (float, optional): Enable baseline-dependent 
-            averaging. The specified size is in number of wavelengths 
-            (i.e., uvw-units). One way to calculate this is with 
+        baseline_averaging (float, optional): Enable baseline-dependent
+            averaging. The specified size is in number of wavelengths
+            (i.e., uvw-units). One way to calculate this is with
                 <baseline in nr. of lambdas> * 2pi *
-                <acceptable integration in s> / (24*60*60). 
+                <acceptable integration in s> / (24*60*60).
             Defaults to None.
-        simulate_noise (float, optional): Will replace every visibility by a 
-            Gaussian distributed value with given standard deviation before 
+        simulate_noise (float, optional): Will replace every visibility by a
+            Gaussian distributed value with given standard deviation before
             imaging. Defaults to None.
-        simulate_baseline_noise (str, optional): Like -simulate-noise, but the 
-            stddevs are provided per baseline, in a text file with antenna1 and 
-            antenna2 indices and the stddev per line, separated by spaces, 
+        simulate_baseline_noise (str, optional): Like -simulate-noise, but the
+            stddevs are provided per baseline, in a text file with antenna1 and
+            antenna2 indices and the stddev per line, separated by spaces,
             e.g. "0 1 3.14". Defaults to None.
-        direct_ft (bool, optional): Do not grid the visibilities on the uv 
-            grid, but instead perform a fully accurate direct  
+        direct_ft (bool, optional): Do not grid the visibilities on the uv
+            grid, but instead perform a fully accurate direct
             Fourier transform (slow!). Defaults to False.
-        use_idg (bool, optional): Use the 'image-domain gridder' 
-            (Van der Tol et al.) to do the inversions and predictions. 
+        use_idg (bool, optional): Use the 'image-domain gridder'
+            (Van der Tol et al.) to do the inversions and predictions.
             Defaults to False.
-        idg_mode (str, optional): Sets the IDG mode. Default: cpu. Hybrid is 
+        idg_mode (str, optional): Sets the IDG mode. Default: cpu. Hybrid is
             recommended when a GPU is available. Defaults to None.
-        use_wgridder (bool, optional): Use the w-gridding gridder developed by 
+        use_wgridder (bool, optional): Use the w-gridding gridder developed by
             Martin Reinecke. Defaults to False.
-        wgridder_accuracy (float, optional): Set the w-gridding accuracy.  
+        wgridder_accuracy (float, optional): Set the w-gridding accuracy.
             Default: 1e-4 Useful range: 1e-2 to 1e-. Defaults to None.
-        aterm_config (str, optional): Specify a parameter set describing how 
-            a-terms should be applied. Please refer to the documentation for 
-            details of the configuration file format. Applying a-terms is only 
+        aterm_config (str, optional): Specify a parameter set describing how
+            a-terms should be applied. Please refer to the documentation for
+            details of the configuration file format. Applying a-terms is only
             possible when IDG is enabled. Defaults to None.
-        grid_with_beam (bool, optional): Apply a-terms to correct for the 
-            primary beam. This is only possible when IDG is enabled. 
+        grid_with_beam (bool, optional): Apply a-terms to correct for the
+            primary beam. This is only possible when IDG is enabled.
             Defaults to False.
-        beam_aterm_update (int, optional): Set the ATerm update time in 
-            seconds. The default is every 300 seconds. It also sets the 
-            interval over which to calculate the primary beam when using 
-            -apply-primary-beam when not gridding with the beam. 
+        beam_aterm_update (int, optional): Set the ATerm update time in
+            seconds. The default is every 300 seconds. It also sets the
+            interval over which to calculate the primary beam when using
+            -apply-primary-beam when not gridding with the beam.
             Defaults to False.
-        aterm_kernel_size (float, optional): Kernel size reserved for aterms 
+        aterm_kernel_size (float, optional): Kernel size reserved for aterms
             by IDG. Defaults to None.
-        apply_facet_solutions (str, optional): Apply solutions from the 
-            provided (h5) file per facet when gridding facet based images. 
-            Provided file is assumed to be in H5Parm format. Filename is 
-            followed by a comma separated list of strings specifying which sol 
+        apply_facet_solutions (str, optional): Apply solutions from the
+            provided (h5) file per facet when gridding facet based images.
+            Provided file is assumed to be in H5Parm format. Filename is
+            followed by a comma separated list of strings specifying which sol
             tabs from the provided H5Parm file are used. Defaults to None.
-        apply_facet_beam (bool, optional): Apply beam gains to facet center 
+        apply_facet_beam (bool, optional): Apply beam gains to facet center
             when gridding facet based image. Defaults to False.
-        facet_beam_update (int, optional): Set the facet beam update time in 
+        facet_beam_update (int, optional): Set the facet beam update time in
             seconds. The default is every 120 seconds. Defaults to False.
-        save_aterms (bool, optional): Output a fits file for every aterm 
-            update, containing the applied image for every station. 
+        save_aterms (bool, optional): Output a fits file for every aterm
+            update, containing the applied image for every station.
             Defaults to False.
-        pol (str, optional): Default: 'I'. 
-            Possible values: XX, XY, YX, YY, I, Q, U, V, RR, RL, LR or LL 
-            (case insensitive). It is allowed but not necessary to separate 
-            with commas, e.g.: 'xx,xy,yx,yy'.Two or four polarizations can be 
-            joinedly cleaned (see '-joinpolarizations'), but this is not the 
-            default. I, Q, U and V polarizations will be directly calculated 
-            from the visibilities, which might require correction to get to 
-            real IQUV values. The 'xy' polarization will output both a real 
-            and an imaginary image, which allows calculating true Stokes 
+        pol (str, optional): Default: 'I'.
+            Possible values: XX, XY, YX, YY, I, Q, U, V, RR, RL, LR or LL
+            (case insensitive). It is allowed but not necessary to separate
+            with commas, e.g.: 'xx,xy,yx,yy'.Two or four polarizations can be
+            joinedly cleaned (see '-joinpolarizations'), but this is not the
+            default. I, Q, U and V polarizations will be directly calculated
+            from the visibilities, which might require correction to get to
+            real IQUV values. The 'xy' polarization will output both a real
+            and an imaginary image, which allows calculating true Stokes
             polarizations for those telescopes. Defaults to None.
-        interval (str, optional): Only image the given time interval. Indices 
-            specify the timesteps, end index is exclusive. Default: image all 
+        interval (str, optional): Only image the given time interval. Indices
+            specify the timesteps, end index is exclusive. Default: image all
             time steps. Defaults to None.
-        intervals_out (int, optional): Number of intervals to image inside the 
+        intervals_out (int, optional): Number of intervals to image inside the
             selected global interval. Default: . Defaults to None.
-        even_timesteps (bool, optional): Only select even timesteps. Can be 
-            used together with -odd-timesteps to determine noise values. 
+        even_timesteps (bool, optional): Only select even timesteps. Can be
+            used together with -odd-timesteps to determine noise values.
             Defaults to False.
-        odd_timesteps (bool, optional): Only select odd timesteps. 
+        odd_timesteps (bool, optional): Only select odd timesteps.
             Defaults to False.
-        channel_range (str, optional): Only image the given channel range. 
-            Indices specify channel indices, end index is exclusive. 
+        channel_range (str, optional): Only image the given channel range.
+            Indices specify channel indices, end index is exclusive.
             Default: image all channels. Defaults to None.
-        field (str, optional): Image the given field id(s). A comma-separated 
-            list of field ids can be provided. When multiple fields are given, 
-            all fields should have the same phase centre. 
-            Specifying '-field all' will image all fields in the 
+        field (str, optional): Image the given field id(s). A comma-separated
+            list of field ids can be provided. When multiple fields are given,
+            all fields should have the same phase centre.
+            Specifying '-field all' will image all fields in the
             measurement set. Default: first field (id 0). Defaults to None.
-        spws (str, optional): Selects only the spws given in the list. list 
-            should be a comma-separated list of integers. Default: all spws. 
+        spws (str, optional): Selects only the spws given in the list. list
+            should be a comma-separated list of integers. Default: all spws.
             Defaults to None.
-        data_column (str, optional): Default: CORRECTED_DATA if it exists, 
+        data_column (str, optional): Default: CORRECTED_DATA if it exists,
             otherwise DATA will be used. Defaults to None.
-        maxuvw_m (float, optional): Set the min max uv distance in lambda. 
+        maxuvw_m (float, optional): Set the min max uv distance in lambda.
             Defaults to None.
-        minuvw_m (float, optional): Set the max baseline distance in meters. 
+        minuvw_m (float, optional): Set the max baseline distance in meters.
             Defaults to None.
-        maxuv_l (float, optional): Set the min max uv distance in lambda. 
+        maxuv_l (float, optional): Set the min max uv distance in lambda.
             Defaults to None.
-        minuv_l (float, optional): Set the max uv distance in lambda. 
+        minuv_l (float, optional): Set the max uv distance in lambda.
             Defaults to None.
-        maxw (float, optional): Do not grid visibilities with a w-value 
-            higher than the given percentage of the max w, to save speed. 
+        maxw (float, optional): Do not grid visibilities with a w-value
+            higher than the given percentage of the max w, to save speed.
             Default: grid everythin. Defaults to None.
-        niter (int, optional): Maximum number of clean iterations to perform. 
+        niter (int, optional): Maximum number of clean iterations to perform.
             Default: 0 (=no cleaning). Defaults to None.
-        nmiter (int, optional): Maximum number of major clean 
-            (inversion/prediction) iterations. Default: 20.A value of 0 means 
+        nmiter (int, optional): Maximum number of major clean
+            (inversion/prediction) iterations. Default: 20.A value of 0 means
             no limit. Defaults to None.
-        threshold (float, optional): Stopping clean thresholding in Jy. 
+        threshold (float, optional): Stopping clean thresholding in Jy.
             Default: 0.0. Defaults to None.
-        auto_threshold (float, optional): Estimate noise level using a robust 
+        auto_threshold (float, optional): Estimate noise level using a robust
             estimator and stop at sigma x stddev. Defaults to None.
-        auto_mask (float, optional): Construct a mask from found components 
-            and when a threshold of sigma is reached, continue cleaning with 
+        auto_mask (float, optional): Construct a mask from found components
+            and when a threshold of sigma is reached, continue cleaning with
             the mask down to the normal threshold. Defaults to None.
-        local_rms (bool, optional): Instead of using a single RMS for auto 
-            thresholding/masking, use a spatially varying RMS image. 
+        local_rms (bool, optional): Instead of using a single RMS for auto
+            thresholding/masking, use a spatially varying RMS image.
             Defaults to False.
-        local_rms_window (bool, optional): Size of window for creating the 
-            RMS background map, in number of PSFs. Default: 25 psfs. 
+        local_rms_window (bool, optional): Size of window for creating the
+            RMS background map, in number of PSFs. Default: 25 psfs.
             Defaults to False.
-        local_rms_method (bool, optional): Either 'rms' 
-            (default, uses sliding window RMS) or 'rms-with-min' 
+        local_rms_method (bool, optional): Either 'rms'
+            (default, uses sliding window RMS) or 'rms-with-min'
             (use max(window rms, 0.3 x window min)). Defaults to False.
-        gain (float, optional): Cleaning gain: Ratio of peak that will be 
+        gain (float, optional): Cleaning gain: Ratio of peak that will be
             subtracted in each iteration. Default: 0.1. Defaults to None.
-        mgain (float, optional): Cleaning gain for major iterations: Ratio of 
-            peak that will be subtracted in each major iteration. 
-            To use major iterations, 0.85 is a good value. 
+        mgain (float, optional): Cleaning gain for major iterations: Ratio of
+            peak that will be subtracted in each major iteration.
+            To use major iterations, 0.85 is a good value.
             Default: 1.0. Defaults to None.
-        join_polarizations (bool, optional): Perform deconvolution by 
-            searching for peaks in the sum of squares of the polarizations, 
-            but subtract components from the individual images. Only possible 
-            when imaging two or four Stokes or linear parameters. 
+        join_polarizations (bool, optional): Perform deconvolution by
+            searching for peaks in the sum of squares of the polarizations,
+            but subtract components from the individual images. Only possible
+            when imaging two or four Stokes or linear parameters.
             Default: off. Defaults to False.
-        link_polarizations (str, optional): Links all polarizations to be 
-            cleaned from the given list: components are found in the given 
+        link_polarizations (str, optional): Links all polarizations to be
+            cleaned from the given list: components are found in the given
             list, but cleaned from all polarizations.  Defaults to None.
-        facet_regions (str, optional): Split the image into facets using the 
-            facet regions defined in  the facets.reg file. Default: off. 
+        facet_regions (str, optional): Split the image into facets using the
+            facet regions defined in  the facets.reg file. Default: off.
             Defaults to None.
-        join_channels (bool, optional): Perform deconvolution by searching for 
-            peaks in the MF image, but subtract components from individual 
-            channels. This will turn on mf-weighting by default. 
+        join_channels (bool, optional): Perform deconvolution by searching for
+            peaks in the MF image, but subtract components from individual
+            channels. This will turn on mf-weighting by default.
             Default: off. Defaults to False.
-        spectral_correction (str, optional): Enable correction of the given 
-            spectral function inside deconvolution. This can e.g. avoid 
-            downweighting higher frequencies because of reduced flux density. 
-            1st term is total flux, 2nd is si, 3rd curvature, etc. 
-            Example: -spectral-correction 150e6 83.084,-0.699,-0.110 
+        spectral_correction (str, optional): Enable correction of the given
+            spectral function inside deconvolution. This can e.g. avoid
+            downweighting higher frequencies because of reduced flux density.
+            1st term is total flux, 2nd is si, 3rd curvature, etc.
+            Example: -spectral-correction 150e6 83.084,-0.699,-0.110
             Defaults to None.
-        no_fast_subminor (bool, optional): Do not use the subminor loop 
-            optimization during (non-multiscale) cleaning. 
+        no_fast_subminor (bool, optional): Do not use the subminor loop
+            optimization during (non-multiscale) cleaning.
             Default: use the optimization. Defaults to False.
-        multiscale (bool, optional): Clean on different scales. 
-            This is a new algorithm. Default: off. This parameter invokes the 
-            optimized multiscale algorithm published by Offringa & Smirnov 
+        multiscale (bool, optional): Clean on different scales.
+            This is a new algorithm. Default: off. This parameter invokes the
+            optimized multiscale algorithm published by Offringa & Smirnov
             (2017). Defaults to False.
-        multiscale_scale_bias (bool, optional): Parameter to prevent cleaning 
-            small scales in the large-scale iterations. A lower bias will give 
+        multiscale_scale_bias (bool, optional): Parameter to prevent cleaning
+            small scales in the large-scale iterations. A lower bias will give
             more focus to larger scales. Default: 0.6 Defaults to False.
-        multiscale_max_scales (int, optional): Set the maximum number of scales 
-            that WSClean should use in multiscale cleaning. Only relevant when 
-            -multiscale-scales is not set. Default: unlimited. 
+        multiscale_max_scales (int, optional): Set the maximum number of scales
+            that WSClean should use in multiscale cleaning. Only relevant when
+            -multiscale-scales is not set. Default: unlimited.
             Defaults to None.
-        multiscale_scales (str, optional): Sets a list of scales to use in 
-            multi-scale cleaning. If unset, WSClean will select the delta 
-            (zero) scale, scales starting at four times the synthesized PSF, 
-            and increase by a factor of two until the maximum scale is reached 
-            or the maximum number of scales is reached. 
+        multiscale_scales (str, optional): Sets a list of scales to use in
+            multi-scale cleaning. If unset, WSClean will select the delta
+            (zero) scale, scales starting at four times the synthesized PSF,
+            and increase by a factor of two until the maximum scale is reached
+            or the maximum number of scales is reached.
             Example: -multiscale-scales 0,5,12.5 Defaults to None.
-        multiscale_shape (str, optional): Sets the shape function used during 
-            multi-scale clean. Either 'tapered-quadratic' (default) or 
+        multiscale_shape (str, optional): Sets the shape function used during
+            multi-scale clean. Either 'tapered-quadratic' (default) or
             'gaussian'. Defaults to None.
-        multiscale_gain (float, optional): Size of step made in the subminor 
-            loop of multi-scale. Default currently 0.2, but shows sign of 
+        multiscale_gain (float, optional): Size of step made in the subminor
+            loop of multi-scale. Default currently 0.2, but shows sign of
             instability. A value of 0.1 might be more stable. Defaults to None.
-        multiscale_convolution_padding (float, optional): Size of zero-padding 
-            for convolutions during the multi-scale cleaning. 
+        multiscale_convolution_padding (float, optional): Size of zero-padding
+            for convolutions during the multi-scale cleaning.
             Default: 1.1 Defaults to None.
-        no_multiscale_fast_subminor (bool, optional): Disable the 
-            'fast subminor loop' optimization, that will only search a part of 
-            the image during the multi-scale subminor loop. The optimization 
+        no_multiscale_fast_subminor (bool, optional): Disable the
+            'fast subminor loop' optimization, that will only search a part of
+            the image during the multi-scale subminor loop. The optimization
             is on by default. Defaults to False.
-        python_deconvolution (str, optional): Run a custom deconvolution 
-            algorithm written in Python. See manual for the interface. 
+        python_deconvolution (str, optional): Run a custom deconvolution
+            algorithm written in Python. See manual for the interface.
             Defaults to None.
-        iuwt (bool, optional): Use the IUWT deconvolution algorithm. 
+        iuwt (bool, optional): Use the IUWT deconvolution algorithm.
             Defaults to False.
-        iuwt_snr_test (bool, optional): Stop IUWT when the SNR decreases. 
-            This might help limitting divergence, but can occasionally also 
-            stop the algorithm too early. Default: no SNR test. 
+        iuwt_snr_test (bool, optional): Stop IUWT when the SNR decreases.
+            This might help limitting divergence, but can occasionally also
+            stop the algorithm too early. Default: no SNR test.
             Defaults to False.
-        no_iuwt_snr_test (bool, optional): Do not stop IUWT when the SNR 
-            decreases. This might help limitting divergence, but can 
-            occasionally also stop the algorithm too early. 
+        no_iuwt_snr_test (bool, optional): Do not stop IUWT when the SNR
+            decreases. This might help limitting divergence, but can
+            occasionally also stop the algorithm too early.
             Default: no SNR test. Defaults to False.
-        moresane_ext (str, optional): Use the MoreSane deconvolution algorithm, 
+        moresane_ext (str, optional): Use the MoreSane deconvolution algorithm,
             installed at the specified location. Defaults to None.
-        moresane_arg (str, optional): Pass the specified arguments to moresane. 
-            Note that multiple parameters have to be enclosed in quotes. 
+        moresane_arg (str, optional): Pass the specified arguments to moresane.
+            Note that multiple parameters have to be enclosed in quotes.
             Defaults to None.
-        moresane_sl (str, optional): MoreSane --sigmalevel setting for each 
-            major loop iteration. Useful to start at high levels and go down 
+        moresane_sl (str, optional): MoreSane --sigmalevel setting for each
+            major loop iteration. Useful to start at high levels and go down
             with subsequent loops, e.g. 20,10,5 Defaults to None.
-        save_source_list (bool, optional): Saves the found clean components 
-            as a BBS/DP3 text sky model. This parameter enables Gaussian shapes 
-            during multi-scale cleaning (-multiscale-shape gaussian). 
+        save_source_list (bool, optional): Saves the found clean components
+            as a BBS/DP3 text sky model. This parameter enables Gaussian shapes
+            during multi-scale cleaning (-multiscale-shape gaussian).
             Defaults to False.
-        clean_border (float, optional): Set the border size in which no 
-            cleaning is performed, in percentage of the width/height of the 
-            image. With an image size of 1000 and clean border of 1%, 
+        clean_border (float, optional): Set the border size in which no
+            cleaning is performed, in percentage of the width/height of the
+            image. With an image size of 1000 and clean border of 1%,
             each border is 10 pixels. Default: 0% Defaults to None.
-        fits_mask (str, optional): Use the specified fits-file as mask during 
+        fits_mask (str, optional): Use the specified fits-file as mask during
             cleaning. Defaults to None.
-        casa_mask (str, optional): Use the specified CASA mask as mask 
+        casa_mask (str, optional): Use the specified CASA mask as mask
         during cleaning. Defaults to None.
         horizon_mask (str, optional): Use a mask that avoids cleaning emission
-            beyond the horizon. Distance is an angle (e.g. "5deg") that 
+            beyond the horizon. Distance is an angle (e.g. "5deg") that
             (when positive) decreases the size of the mask to stay further away
             from the horizon. Defaults to None.
-        no_negative (bool, optional): Do not allow negative components during 
+        no_negative (bool, optional): Do not allow negative components during
             cleaning. Not the default. Defaults to False.
-        negative (bool, optional): Default on: opposite of -nonegative. 
+        negative (bool, optional): Default on: opposite of -nonegative.
             Defaults to False.
-        stop_negative (bool, optional): Stop on negative components. 
+        stop_negative (bool, optional): Stop on negative components.
             Not the default. Defaults to False.
-        fit_spectral_pol (int, optional): Fit a polynomial over frequency to 
-            each clean component. This has only effect when the channels are 
+        fit_spectral_pol (int, optional): Fit a polynomial over frequency to
+            each clean component. This has only effect when the channels are
             joined with -join-channels. Defaults to None.
-        fit_spectral_log_pol (int, optional): Like fit-spectral-pol, but fits 
+        fit_spectral_log_pol (int, optional): Like fit-spectral-pol, but fits
             a logarithmic polynomial over frequency instead. Defaults to None.
-        force_spectrum (str, optional): Uses the fits file to force spectral 
-            indices (or other/more terms)during the deconvolution. 
+        force_spectrum (str, optional): Uses the fits file to force spectral
+            indices (or other/more terms)during the deconvolution.
             Defaults to None.
         deconvolution_channels (int, optional): Decrease the number of channels
-            as specified by -channels-out to the given number for 
-            deconvolution. Only possible in combination with one of the 
-            -fit-spectral options. Proper residuals/restored images will 
+            as specified by -channels-out to the given number for
+            deconvolution. Only possible in combination with one of the
+            -fit-spectral options. Proper residuals/restored images will
             only be returned when mgain < 1. Defaults to None.
         squared_channel_joining (bool, optional): Use with -join-channels to
-            perform peak finding in the sum of squared values over channels, 
-            instead of the normal sum. This is useful for imaging QU 
+            perform peak finding in the sum of squared values over channels,
+            instead of the normal sum. This is useful for imaging QU
             polarizations with non-zero rotation measures, for which the normal
              sum is insensitive. Defaults to False.
         parallel_deconvolution (int, optional): Deconvolve subimages in
-            parallel. Subimages will be at most of the given size. 
+            parallel. Subimages will be at most of the given size.
             Defaults to None.
         deconvolution_threads (int, optional): Number of threads to use during
             deconvolution. On machines with a large nr of cores, this may be
@@ -722,7 +722,7 @@ def wsclean(
              are read from the residual image. If this parameter is given,
               wsclean will do the restoring and then exit:
             no cleaning is performed. Defaults to None.
-        restore_list (str, optional): Restore a source list onto the residual 
+        restore_list (str, optional): Restore a source list onto the residual
             image and save it in output image. Except for the model input
             format, this parameter behaves equal to -restore. Defaults to None.
         beam_size (float, optional): Set a circular beam size (FWHM) in arcsec
@@ -730,8 +730,8 @@ def wsclean(
             -beam-shape <size> <size> 0. Defaults to None.
         beam_shape (str, optional): Set the FWHM beam shape for restoring the
             clean components. Defaults units for maj and min are arcsec, and
-            degrees for PA. Can be overriden, 
-            e.g. '-beam-shape 1amin 1amin 3deg'. 
+            degrees for PA. Can be overriden,
+            e.g. '-beam-shape 1amin 1amin 3deg'.
             Default: shape of PSF. Defaults to None.
         fit_beam (bool, optional): Determine beam shape by fitting the PSF
             (default if PSF is made). Defaults to False.
@@ -743,9 +743,9 @@ def wsclean(
         theoretic_beam (bool, optional): Write the beam in output fits files as
             calculated from the longest projected baseline. This method results
             in slightly less accurate beam size/integrated fluxes, but provides
-             a beam size without making the PSF for quick imaging. 
+             a beam size without making the PSF for quick imaging.
              Default: off. Defaults to False.
-        circular_beam (bool, optional): Force the beam to be circular: 
+        circular_beam (bool, optional): Force the beam to be circular:
             bmin will be set to bmaj. Defaults to False.
         elliptical_beam (bool, optional): Allow the beam to be elliptical.
             Default. Defaults to False.
@@ -804,7 +804,8 @@ def call_wsclean(inputMS, conf, use_mpi=False):
         log_time=conf.input.log_time,
         temp_dir=conf.env.dirImages,
         mem=conf.input.mem,
-        parallel_deconvolution=conf.input.imsize // conf.input.threads,
+        parallel_deconvolution=conf.input.imsize // int(np.floor(np.sqrt(conf.input.threads))),
+        iuwt=conf.input.iuwt,
     )
     info(f"wsclean command: {command}")
     sp.run(command.split())
@@ -833,7 +834,7 @@ def call_wsclean(inputMS, conf, use_mpi=False):
         head = fits.getheader(stack[stokes[0]])
         data = np.concatenate([fits.getdata(stack[s]) for s in stokes])
         # Make a casa-compatible fits file
-        casaname = f"{prefix}.chan{c:03d}.image.fits"
+        casaname = f"{prefix}.chan{c+1:03d}.image.fits"
         info(f"Writing casa-compatible fits file: {casaname}")
         fits.writeto(casaname, data, head, overwrite=True)
 

--- a/frocc/cube_wsclean.py
+++ b/frocc/cube_wsclean.py
@@ -1,0 +1,903 @@
+#!/usr/bin/env python3
+"""
+------------------------------------------------------------------------------
+
+------------------------------------------------------------------------------
+Developed at: IDIA (Institure for Data Intensive Astronomy), Cape Town, ZA
+Inspired by: https://github.com/idia-astro/image-generator
+
+Lennart Heino
+------------------------------------------------------------------------------
+"""
+
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+
+from concurrent.futures import thread
+import numpy as np
+import sys
+import logging
+import datetime
+import os
+from glob import glob
+from logging import info, error
+import subprocess as sp
+from radio_beam import Beam, Beams
+from astropy.io import fits
+from astropy import units
+
+import click
+
+import casatasks
+
+from frocc.config import FILEPATH_CONFIG_TEMPLATE, FILEPATH_CONFIG_USER
+from frocc.lhelpers import (
+    get_dict_from_click_args,
+    DotMap,
+    get_config_in_dot_notation,
+    get_firstFreq,
+    SEPERATOR,
+    SEPERATOR_HEAVY,
+)
+
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+# SETTINGS
+
+logging.basicConfig(
+    format="%(asctime)s\t[ %(levelname)s ]\t%(message)s", level=logging.INFO
+)
+
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+# QUICKFIX
+
+# Otherwise casa log files get confused
+import functools
+import inspect
+
+
+def main_timer(func):
+    """
+    """
+
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        TIMESTAMP_START = datetime.datetime.now()
+        info(SEPERATOR_HEAVY)
+        info(f"STARTING script: {inspect.stack()[-1].filename}")
+        info(SEPERATOR)
+
+        func(*args, **kwargs)
+
+        TIMESTAMP_END = datetime.datetime.now()
+        TIMESTAMP_DELTA = TIMESTAMP_END - TIMESTAMP_START
+        info(SEPERATOR)
+        info(f"END script in {TIMESTAMP_DELTA}: {inspect.stack()[-1].filename}")
+        info(SEPERATOR_HEAVY)
+
+    return wrapper
+
+
+# QUICKFIX
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+
+
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+
+
+def wsclean(
+    mslist: list,
+    use_mpi: bool,
+    version: bool = False,
+    j: int = None,
+    parallel_gridding: int = None,
+    parallel_reordering: int = None,
+    no_work_on_master: bool = False,
+    mem: float = None,
+    abs_mem: float = None,
+    verbose: bool = False,
+    log_time: bool = False,
+    quiet: bool = False,
+    reorder: bool = False,
+    no_reorder: bool = False,
+    temp_dir: str = None,
+    update_model_required: bool = False,
+    no_update_model_required: bool = False,
+    no_dirty: bool = False,
+    save_first_residual: bool = False,
+    save_weights: bool = False,
+    save_uv: bool = False,
+    reuse_psf: str = None,
+    reuse_dirty: str = None,
+    apply_primary_beam: bool = False,
+    reuse_primary_beam: bool = False,
+    use_differential_lofar_beam: bool = False,
+    primary_beam_limit: float = None,
+    mwa_path: str = None,
+    save_psf_pb: bool = False,
+    pb_grid_size: int = None,
+    beam_model: str = None,
+    beam_mode: str = None,
+    beam_normalisation_mode: str = None,
+    dry_run: bool = False,
+    weight: str = None,
+    super_weight: float = None,
+    mf_weighting: bool = False,
+    no_mf_weighting: bool = False,
+    weighting_rank_filter: float = None,
+    weighting_rank_filter_size: float = None,
+    taper_gaussian: str = None,
+    taper_tukey: float = None,
+    taper_inner_tukey: float = None,
+    taper_edge: float = None,
+    taper_edge_tukey: float = None,
+    use_weights_as_taper: bool = False,
+    store_imaging_weights: bool = False,
+    name: str = None,
+    size: str = None,
+    padding: float = None,
+    scale: str = None,
+    predict: bool = False,
+    ws_continue: bool = False,
+    subtract_model: bool = False,
+    channels_out: int = None,
+    shift: str = None,
+    gap_channel_division: bool = False,
+    channel_division_frequencies: str = None,
+    nwlayers: int = None,
+    nwlayers_factor: float = None,
+    nwlayers_for_size: str = None,
+    no_small_inversion: bool = False,
+    small_inversion: bool = False,
+    grid_mode: str = None,
+    kernel_size: int = None,
+    oversampling: int = None,
+    make_psf: bool = False,
+    make_psf_only: bool = False,
+    visibility_weighting_mode: str = None,
+    no_normalize_for_weighting: bool = False,
+    baseline_averaging: float = None,
+    simulate_noise: float = None,
+    simulate_baseline_noise: str = None,
+    direct_ft: bool = False,
+    use_idg: bool = False,
+    idg_mode: str = None,
+    use_wgridder: bool = False,
+    wgridder_accuracy: float = None,
+    aterm_config: str = None,
+    grid_with_beam: bool = False,
+    beam_aterm_update: int = False,
+    aterm_kernel_size: float = None,
+    apply_facet_solutions: str = None,
+    apply_facet_beam: bool = False,
+    facet_beam_update: int = False,
+    save_aterms: bool = False,
+    pol: str = None,
+    interval: str = None,
+    intervals_out: int = None,
+    even_timesteps: bool = False,
+    odd_timesteps: bool = False,
+    channel_range: str = None,
+    field: str = None,
+    spws: str = None,
+    data_column: str = None,
+    maxuvw_m: float = None,
+    minuvw_m: float = None,
+    maxuv_l: float = None,
+    minuv_l: float = None,
+    maxw: float = None,
+    niter: int = None,
+    nmiter: int = None,
+    threshold: float = None,
+    auto_threshold: float = None,
+    auto_mask: float = None,
+    local_rms: bool = False,
+    local_rms_window: bool = False,
+    local_rms_method: bool = False,
+    gain: float = None,
+    mgain: float = None,
+    join_polarizations: bool = False,
+    link_polarizations: str = None,
+    facet_regions: str = None,
+    join_channels: bool = False,
+    spectral_correction: str = None,
+    no_fast_subminor: bool = False,
+    multiscale: bool = False,
+    multiscale_scale_bias: bool = False,
+    multiscale_max_scales: int = None,
+    multiscale_scales: str = None,
+    multiscale_shape: str = None,
+    multiscale_gain: float = None,
+    multiscale_convolution_padding: float = None,
+    no_multiscale_fast_subminor: bool = False,
+    python_deconvolution: str = None,
+    iuwt: bool = False,
+    iuwt_snr_test: bool = False,
+    no_iuwt_snr_test: bool = False,
+    moresane_ext: str = None,
+    moresane_arg: str = None,
+    moresane_sl: str = None,
+    save_source_list: bool = False,
+    clean_border: float = None,
+    fits_mask: str = None,
+    casa_mask: str = None,
+    horizon_mask: str = None,
+    no_negative: bool = False,
+    negative: bool = False,
+    stop_negative: bool = False,
+    fit_spectral_pol: int = None,
+    fit_spectral_log_pol: int = None,
+    force_spectrum: str = None,
+    deconvolution_channels: int = None,
+    squared_channel_joining: bool = False,
+    parallel_deconvolution: int = None,
+    deconvolution_threads: int = None,
+    restore: str = None,
+    restore_list: str = None,
+    beam_size: float = None,
+    beam_shape: str = None,
+    fit_beam: bool = False,
+    no_fit_beam: bool = False,
+    beam_fitting_size: float = None,
+    theoretic_beam: bool = False,
+    circular_beam: bool = False,
+    elliptical_beam: bool = False,
+):
+    """Construct a wsclean command.
+
+    If False or None is passed as a parameter, the parameter is not included 
+    in the command (i.e. wsclean will assume a default value).
+
+    Args:
+        mslist (list): List of MSs to be processed.
+        use_mpi (bool): Use wsclean-mp for parallel processing.
+        version (bool, optional): Print WSClean's version and exit. 
+            Defaults to False.
+        j (int, optional): Specify number of computing threads to use, 
+            i.e., number of cpu cores that will be used. 
+            Default: use all cpu cores. to None.
+        parallel_gridding (int, optional): Will execute multiple gridders 
+            simultaneously. This can make things faster in certain cases, 
+            but will increase memory usage. Defaults to None.
+        parallel_reordering (int, optional): Process the reordering with 
+            multipliple threads. Defaults to None.
+        no_work_on_master (bool, optional): In MPI runs, do not use the master 
+            for gridding. This may be useful if the resources such as memory 
+            of the master are limited. Defaults to False.
+        mem (float, optional): Limit memory usage to the given fraction of the 
+            total system memory. This is an approximate value. 
+            Default: 100. Defaults to None.
+        abs_mem (float, optional): Like -mem, but this specifies a fixed amount 
+            of memory in gigabytes. Defaults to None.
+        verbose (bool, optional): Increase verbosity of output. 
+            Defaults to False.
+        log_time (bool, optional): Add date and time to each line in the 
+            output. Defaults to False.
+        quiet (bool, optional): Do not output anything but errors. 
+            Defaults to False.
+        reorder (bool, optional): Force reordering of Measurement Set. 
+            This can be faster when the measurement set needs to be iterated 
+            several times, such as with many major iterations or in channel 
+            imaging mode. Default: only reorder when in channel imaging mode. 
+            Defaults to False.
+        no_reorder (bool, optional): Disable reordering of Measurement Set. 
+            This can be faster when the measurement set needs to be iterated 
+            several times, such as with many major iterations or in channel 
+            imaging mode. Default: only reorder when in channel imaging mode. 
+            Defaults to False.
+        temp_dir (str, optional): Set the temporary directory used when 
+            reordering files. Default: same directory as input measurement set. 
+            Defaults to None.
+        update_model_required (bool, optional): Default. Defaults to False.
+        no_update_model_required (bool, optional): These two options specify 
+            whether the model data column is required to contain valid model 
+            data after imaging. It can save time to not update the model data 
+            column. Defaults to False.
+        no_dirty (bool, optional): Do not save the dirty image. 
+            Defaults to False.
+        save_first_residual (bool, optional): Save the residual after the 
+            first iteration. Defaults to False.
+        save_weights (bool, optional): Save the gridded weights in the a fits 
+            file named <image-prefix>-weights.fits. Defaults to False.
+        save_uv (bool, optional): Save the gridded uv plane, i.e., the FFT of 
+            the residual image. The UV plane is complex, hence two images will 
+            be output: <prefix>-uv-real.fits and <prefix>-uv-imag.fits. 
+            Defaults to False.
+        reuse_psf (str, optional): Load the psf(s) from the given prefix and 
+            skip the inversion for the psf image. Defaults to None.
+        reuse_dirty (str, optional): Load the dirty from the given prefix and 
+            skip the inversion for the dirty image. Defaults to None.
+        apply_primary_beam (bool, optional): Calculate and apply the primary 
+            beam and save images for the Jones components, with weighting 
+            identical to the weighting as used by the imager. Only available 
+            for instruments supported by EveryBeam. Defaults to False.
+        reuse_primary_beam (bool, optional): If a primary beam image exists 
+            on disk, reuse those images. Defaults to False.
+        use_differential_lofar_beam (bool, optional): Assume the visibilities 
+            have already been beam-corrected for the reference direction. 
+            By default, WSClean will use the information in the measurement 
+            set to determine if the differential beam should be applied for 
+            obtaining proper flux levels. Defaults to False.
+        primary_beam_limit (float, optional): Level at which to trim the beam 
+            when performing image-based beam correction,. Default: 0.005. 
+            Defaults to None.
+        mwa_path (str, optional): Set path where to find the MWA beam file(s). 
+            Defaults to None.
+        save_psf_pb (bool, optional): When applying beam correction, 
+            also save the primary-beam corrected PSF image. Defaults to False.
+        pb_grid_size (int, optional): Specify the grid size in number of 
+            pixels at which to evaluate the primary beam. 
+            Typically, the primary beam is calculated at a coarse resolution 
+            grid and interpolated, to reduce the time spent in evaluating the 
+            beam. This parameter controls the resolution of the grid at which 
+            to evaluate the primary beam. For rectangular images, pb-grid-size 
+            indicates the number of pixels along the shortest dimension. 
+            The total number of pixels in the primary beam grid thus amounts 
+            to: 
+                max(width, height) / min(width, height) * pb-grid-size**2. 
+            Default: 32. Defaults to None.
+        beam_model (str, optional): Specify the beam model, only relevant for 
+            SKA and LOFAR. Available models are Hamaker, Lobes, OskarDipole, 
+            OskarSphericalWave. Input is case insensitive. Default is Hamaker 
+            for LOFAR and OskarSphericalWave for SKA. Defaults to None.
+        beam_mode (str, optional): [DEBUGGING ONLY] Manually specify the 
+            beam mode. Only relevant for simulated SKA measurement sets. 
+            Available modes are array_factor, element and full. Input is case 
+            insensitive. Default is full. Defaults to None.
+        beam_normalisation_mode (str, optional): [DEBUGGING ONLY] 
+            Manually specify the normalisation of the beam. Only relevant 
+            for simulated SKA measurement sets. Available modes are none, 
+            preapplied, full, and amplitude. Default is preapplied. 
+            Defaults to None.
+        dry_run (bool, optional): Parses the command line and quits afterwards.
+            No imaging is done. Defaults to False.
+        weight (str, optional): Weightmode can be: natural, uniform, briggs. 
+            Default: uniform. When using Briggs' weighting, add the robustness 
+            parameter, like: "-weight briggs 0.5". Defaults to None.
+        super_weight (float, optional): Increase the weight gridding box size, 
+            similar to Casa's superuniform weighting scheme. Default: 1.0 
+            The factor can be rational and can be less than one for subpixel 
+            weighting. Defaults to None.
+        mf_weighting (bool, optional): In spectral mode, calculate the weights 
+            as if the image was made using MF. This makes sure that the sum of 
+            channel images equals the MF weights. Otherwise, the channel image 
+            will become a bit more naturally weighted. This is only relevant 
+            for weighting modes that require gridding (i.e., Uniform, Briggs'). 
+            Default: off, unless -join-channels is specified. 
+            Defaults to False.
+        no_mf_weighting (bool, optional): Opposite of -ms-weighting; 
+            can be used to turn off MF weighting in -join-channels mode. 
+            Defaults to False.
+        weighting_rank_filter (float, optional): Filter the weights and set 
+            high weights to the local mean. The level parameter specifies the 
+            filter level; any value larger than level*localmean will be set to 
+            level*localmean. Defaults to None.
+        weighting_rank_filter_size (float, optional): Set size of weighting 
+            rank filter. Default: 16. Defaults to None.
+        taper_gaussian (str, optional): Taper the weights with a Gaussian 
+            function. This will reduce the contribution of long baselines. 
+            The beamsize is by default in asec, but a unit can be specified 
+            ("2amin"). Defaults to None.
+        taper_tukey (float, optional): Taper the outer weights with a Tukey 
+            transition. Lambda specifies the size of the transition; use in 
+            combination with -maxuv-l. Defaults to None.
+        taper_inner_tukey (float, optional): Taper the weights with a Tukey 
+            transition. Lambda specifies the size of the transition; use in 
+            combination with -minuv-l. Defaults to None.
+        taper_edge (float, optional): Taper the weights with a rectangle, 
+            to keep a space of lambda between the edge and gridded 
+            visibilities. Defaults to None.
+        taper_edge_tukey (float, optional): Taper the edge weights with a Tukey 
+            window. Lambda is the size of the Tukey transition. When 
+            -taper-edge is also specified, the Tukey transition starts inside 
+            the inner rectangle. Defaults to None.
+        use_weights_as_taper (bool, optional): Will not use visibility weights 
+            when determining the imaging weights. This has the effect that e.g. 
+            uniform weighting can be modified by increasing the visibility 
+            weight of certain baselines. Without this option, uniform imaging 
+            weights absorb the visibility weight to make the weighting truly 
+            uniform. Defaults to False.
+        store_imaging_weights (bool, optional): Will store the imaging weights 
+            in a column named 'IMAGING_WEIGHT_SPECTRUM'. Defaults to False.
+        name (str, optional): Use image-prefix as prefix for output files. 
+            Default is 'wsclean'. Defaults to None.
+        size (str, optional): Set the output image size in number of pixels 
+            (without padding). Defaults to None.
+        padding (float, optional): Pad images by the given factor during 
+            inversion to avoid aliasing. Default: 1.2 (=20%). Defaults to None.
+        scale (str, optional): Scale of a pixel. Default unit is degrees, but 
+            can be specificied, e.g. -scale 20asec. Default: 0.01deg. 
+            Defaults to None.
+        predict (bool, optional): Only perform a single prediction for an 
+            existing image. Doesn't do any imaging or cleaning. The input 
+            images should have the same name as the model output images would 
+            have in normal imaging mode. Defaults to False.
+        ws_continue (bool, optional): Will continue an earlier WSClean run. 
+            Earlier model images will be read and model visibilities will be 
+            subtracted to create the first dirty residual. CS should have been 
+            used in the earlier run, and model datashould have been written 
+            to the measurement set for this to work. Default: off. 
+            Defaults to False.
+        subtract_model (bool, optional): Subtract the model from the 
+            data column in the first iteration. This can be used to reimage 
+            an already cleaned image, e.g. at a different resolution. 
+            Defaults to False.
+        channels_out (int, optional): Splits the bandwidth and makes count 
+            nr. of images. Default: 1. Defaults to None.
+        shift (str, optional): Shift the phase centre to the given location. 
+            The shift is along the tangential plane. Defaults to None.
+        gap_channel_division (bool, optional): In case of irregular frequency 
+            spacing, this option can be used to not try and split channels to 
+            make the output channel bandwidth similar, but instead to split 
+            largest gaps first. Defaults to False.
+        channel_division_frequencies (str, optional): Split the bandwidth at 
+            the specified frequencies (in Hz) before the normal bandwidth 
+            division is performed. This can e.g. be useful for imaging multiple 
+            bands with irregular number of channels. Defaults to None.
+        nwlayers (int, optional): Number of w-layers to use. Default: minimum 
+            suggested #w-layers for first MS. Defaults to None.
+        nwlayers_factor (float, optional): Use automatic calculation of the 
+            number of w-layers, but multiple that number by the given factor. 
+            This can e.g. be useful for increasing w-accuracy. Defaults to None.
+        nwlayers_for_size (str, optional): Use the minimum suggested w-layers 
+            for an image of the given size. Can e.g. be used to increase 
+            accuracy when predicting small part of full image. 
+            Defaults to None.
+        no_small_inversion (bool, optional): Perform inversion at the Nyquist 
+            resolution and upscale the image to the requested image size 
+            afterwards. This speeds up inversion considerably, but makes 
+            aliasing slightly worse. This effect is in most cases <1%. 
+            Default: on. Defaults to False.
+        small_inversion (bool, optional): Perform inversion at the 
+            Nyquist resolution and upscale the image to the requested 
+            image size afterwards. This speeds up inversion considerably, 
+            but makes aliasing slightly worse. This effect is in most cases 
+            <1%. Default: on. Defaults to False.
+        grid_mode (str, optional): Kernel and mode used for gridding: 
+            kb = Kaiser-Bessel (default with 7 pixels), nn = nearest neighbour 
+            (no kernel), more options: rect, kb-no-sinc, gaus, bn. Default: kb. 
+            Defaults to None.
+        kernel_size (int, optional): Gridding antialiasing kernel size. 
+            Default: 7. Defaults to None.
+        oversampling (int, optional): Oversampling factor used during gridding. 
+            Default: 63. Defaults to None.
+        make_psf (bool, optional): Always make the psf, even when no cleaning 
+            is performed. Defaults to False.
+        make_psf_only (bool, optional): Only make the psf, no images are made. 
+            Defaults to False.
+        visibility_weighting_mode (str, optional): Specify visibility weighting 
+            modi. Affects how the weights (normally) stored in WEIGHT_SPECTRUM 
+            column are applied. Useful for estimating e.g. EoR power spectra 
+            errors. Normally one would use this in combination with 
+            -no-normalize-for-weighting. Defaults to None.
+        no_normalize_for_weighting (bool, optional): Disable the normalization 
+            for the weights, which makes the PSF's peak one. 
+            See -visibility-weighting-mode. Only useful with natural weighting. 
+            Defaults to False.
+        baseline_averaging (float, optional): Enable baseline-dependent 
+            averaging. The specified size is in number of wavelengths 
+            (i.e., uvw-units). One way to calculate this is with 
+                <baseline in nr. of lambdas> * 2pi *
+                <acceptable integration in s> / (24*60*60). 
+            Defaults to None.
+        simulate_noise (float, optional): Will replace every visibility by a 
+            Gaussian distributed value with given standard deviation before 
+            imaging. Defaults to None.
+        simulate_baseline_noise (str, optional): Like -simulate-noise, but the 
+            stddevs are provided per baseline, in a text file with antenna1 and 
+            antenna2 indices and the stddev per line, separated by spaces, 
+            e.g. "0 1 3.14". Defaults to None.
+        direct_ft (bool, optional): Do not grid the visibilities on the uv 
+            grid, but instead perform a fully accurate direct  
+            Fourier transform (slow!). Defaults to False.
+        use_idg (bool, optional): Use the 'image-domain gridder' 
+            (Van der Tol et al.) to do the inversions and predictions. 
+            Defaults to False.
+        idg_mode (str, optional): Sets the IDG mode. Default: cpu. Hybrid is 
+            recommended when a GPU is available. Defaults to None.
+        use_wgridder (bool, optional): Use the w-gridding gridder developed by 
+            Martin Reinecke. Defaults to False.
+        wgridder_accuracy (float, optional): Set the w-gridding accuracy.  
+            Default: 1e-4 Useful range: 1e-2 to 1e-. Defaults to None.
+        aterm_config (str, optional): Specify a parameter set describing how 
+            a-terms should be applied. Please refer to the documentation for 
+            details of the configuration file format. Applying a-terms is only 
+            possible when IDG is enabled. Defaults to None.
+        grid_with_beam (bool, optional): Apply a-terms to correct for the 
+            primary beam. This is only possible when IDG is enabled. 
+            Defaults to False.
+        beam_aterm_update (int, optional): Set the ATerm update time in 
+            seconds. The default is every 300 seconds. It also sets the 
+            interval over which to calculate the primary beam when using 
+            -apply-primary-beam when not gridding with the beam. 
+            Defaults to False.
+        aterm_kernel_size (float, optional): Kernel size reserved for aterms 
+            by IDG. Defaults to None.
+        apply_facet_solutions (str, optional): Apply solutions from the 
+            provided (h5) file per facet when gridding facet based images. 
+            Provided file is assumed to be in H5Parm format. Filename is 
+            followed by a comma separated list of strings specifying which sol 
+            tabs from the provided H5Parm file are used. Defaults to None.
+        apply_facet_beam (bool, optional): Apply beam gains to facet center 
+            when gridding facet based image. Defaults to False.
+        facet_beam_update (int, optional): Set the facet beam update time in 
+            seconds. The default is every 120 seconds. Defaults to False.
+        save_aterms (bool, optional): Output a fits file for every aterm 
+            update, containing the applied image for every station. 
+            Defaults to False.
+        pol (str, optional): Default: 'I'. 
+            Possible values: XX, XY, YX, YY, I, Q, U, V, RR, RL, LR or LL 
+            (case insensitive). It is allowed but not necessary to separate 
+            with commas, e.g.: 'xx,xy,yx,yy'.Two or four polarizations can be 
+            joinedly cleaned (see '-joinpolarizations'), but this is not the 
+            default. I, Q, U and V polarizations will be directly calculated 
+            from the visibilities, which might require correction to get to 
+            real IQUV values. The 'xy' polarization will output both a real 
+            and an imaginary image, which allows calculating true Stokes 
+            polarizations for those telescopes. Defaults to None.
+        interval (str, optional): Only image the given time interval. Indices 
+            specify the timesteps, end index is exclusive. Default: image all 
+            time steps. Defaults to None.
+        intervals_out (int, optional): Number of intervals to image inside the 
+            selected global interval. Default: . Defaults to None.
+        even_timesteps (bool, optional): Only select even timesteps. Can be 
+            used together with -odd-timesteps to determine noise values. 
+            Defaults to False.
+        odd_timesteps (bool, optional): Only select odd timesteps. 
+            Defaults to False.
+        channel_range (str, optional): Only image the given channel range. 
+            Indices specify channel indices, end index is exclusive. 
+            Default: image all channels. Defaults to None.
+        field (str, optional): Image the given field id(s). A comma-separated 
+            list of field ids can be provided. When multiple fields are given, 
+            all fields should have the same phase centre. 
+            Specifying '-field all' will image all fields in the 
+            measurement set. Default: first field (id 0). Defaults to None.
+        spws (str, optional): Selects only the spws given in the list. list 
+            should be a comma-separated list of integers. Default: all spws. 
+            Defaults to None.
+        data_column (str, optional): Default: CORRECTED_DATA if it exists, 
+            otherwise DATA will be used. Defaults to None.
+        maxuvw_m (float, optional): Set the min max uv distance in lambda. 
+            Defaults to None.
+        minuvw_m (float, optional): Set the max baseline distance in meters. 
+            Defaults to None.
+        maxuv_l (float, optional): Set the min max uv distance in lambda. 
+            Defaults to None.
+        minuv_l (float, optional): Set the max uv distance in lambda. 
+            Defaults to None.
+        maxw (float, optional): Do not grid visibilities with a w-value 
+            higher than the given percentage of the max w, to save speed. 
+            Default: grid everythin. Defaults to None.
+        niter (int, optional): Maximum number of clean iterations to perform. 
+            Default: 0 (=no cleaning). Defaults to None.
+        nmiter (int, optional): Maximum number of major clean 
+            (inversion/prediction) iterations. Default: 20.A value of 0 means 
+            no limit. Defaults to None.
+        threshold (float, optional): Stopping clean thresholding in Jy. 
+            Default: 0.0. Defaults to None.
+        auto_threshold (float, optional): Estimate noise level using a robust 
+            estimator and stop at sigma x stddev. Defaults to None.
+        auto_mask (float, optional): Construct a mask from found components 
+            and when a threshold of sigma is reached, continue cleaning with 
+            the mask down to the normal threshold. Defaults to None.
+        local_rms (bool, optional): Instead of using a single RMS for auto 
+            thresholding/masking, use a spatially varying RMS image. 
+            Defaults to False.
+        local_rms_window (bool, optional): Size of window for creating the 
+            RMS background map, in number of PSFs. Default: 25 psfs. 
+            Defaults to False.
+        local_rms_method (bool, optional): Either 'rms' 
+            (default, uses sliding window RMS) or 'rms-with-min' 
+            (use max(window rms, 0.3 x window min)). Defaults to False.
+        gain (float, optional): Cleaning gain: Ratio of peak that will be 
+            subtracted in each iteration. Default: 0.1. Defaults to None.
+        mgain (float, optional): Cleaning gain for major iterations: Ratio of 
+            peak that will be subtracted in each major iteration. 
+            To use major iterations, 0.85 is a good value. 
+            Default: 1.0. Defaults to None.
+        join_polarizations (bool, optional): Perform deconvolution by 
+            searching for peaks in the sum of squares of the polarizations, 
+            but subtract components from the individual images. Only possible 
+            when imaging two or four Stokes or linear parameters. 
+            Default: off. Defaults to False.
+        link_polarizations (str, optional): Links all polarizations to be 
+            cleaned from the given list: components are found in the given 
+            list, but cleaned from all polarizations.  Defaults to None.
+        facet_regions (str, optional): Split the image into facets using the 
+            facet regions defined in  the facets.reg file. Default: off. 
+            Defaults to None.
+        join_channels (bool, optional): Perform deconvolution by searching for 
+            peaks in the MF image, but subtract components from individual 
+            channels. This will turn on mf-weighting by default. 
+            Default: off. Defaults to False.
+        spectral_correction (str, optional): Enable correction of the given 
+            spectral function inside deconvolution. This can e.g. avoid 
+            downweighting higher frequencies because of reduced flux density. 
+            1st term is total flux, 2nd is si, 3rd curvature, etc. 
+            Example: -spectral-correction 150e6 83.084,-0.699,-0.110 
+            Defaults to None.
+        no_fast_subminor (bool, optional): Do not use the subminor loop 
+            optimization during (non-multiscale) cleaning. 
+            Default: use the optimization. Defaults to False.
+        multiscale (bool, optional): Clean on different scales. 
+            This is a new algorithm. Default: off. This parameter invokes the 
+            optimized multiscale algorithm published by Offringa & Smirnov 
+            (2017). Defaults to False.
+        multiscale_scale_bias (bool, optional): Parameter to prevent cleaning 
+            small scales in the large-scale iterations. A lower bias will give 
+            more focus to larger scales. Default: 0.6 Defaults to False.
+        multiscale_max_scales (int, optional): Set the maximum number of scales 
+            that WSClean should use in multiscale cleaning. Only relevant when 
+            -multiscale-scales is not set. Default: unlimited. 
+            Defaults to None.
+        multiscale_scales (str, optional): Sets a list of scales to use in 
+            multi-scale cleaning. If unset, WSClean will select the delta 
+            (zero) scale, scales starting at four times the synthesized PSF, 
+            and increase by a factor of two until the maximum scale is reached 
+            or the maximum number of scales is reached. 
+            Example: -multiscale-scales 0,5,12.5 Defaults to None.
+        multiscale_shape (str, optional): Sets the shape function used during 
+            multi-scale clean. Either 'tapered-quadratic' (default) or 
+            'gaussian'. Defaults to None.
+        multiscale_gain (float, optional): Size of step made in the subminor 
+            loop of multi-scale. Default currently 0.2, but shows sign of 
+            instability. A value of 0.1 might be more stable. Defaults to None.
+        multiscale_convolution_padding (float, optional): Size of zero-padding 
+            for convolutions during the multi-scale cleaning. 
+            Default: 1.1 Defaults to None.
+        no_multiscale_fast_subminor (bool, optional): Disable the 
+            'fast subminor loop' optimization, that will only search a part of 
+            the image during the multi-scale subminor loop. The optimization 
+            is on by default. Defaults to False.
+        python_deconvolution (str, optional): Run a custom deconvolution 
+            algorithm written in Python. See manual for the interface. 
+            Defaults to None.
+        iuwt (bool, optional): Use the IUWT deconvolution algorithm. 
+            Defaults to False.
+        iuwt_snr_test (bool, optional): Stop IUWT when the SNR decreases. 
+            This might help limitting divergence, but can occasionally also 
+            stop the algorithm too early. Default: no SNR test. 
+            Defaults to False.
+        no_iuwt_snr_test (bool, optional): Do not stop IUWT when the SNR 
+            decreases. This might help limitting divergence, but can 
+            occasionally also stop the algorithm too early. 
+            Default: no SNR test. Defaults to False.
+        moresane_ext (str, optional): Use the MoreSane deconvolution algorithm, 
+            installed at the specified location. Defaults to None.
+        moresane_arg (str, optional): Pass the specified arguments to moresane. 
+            Note that multiple parameters have to be enclosed in quotes. 
+            Defaults to None.
+        moresane_sl (str, optional): MoreSane --sigmalevel setting for each 
+            major loop iteration. Useful to start at high levels and go down 
+            with subsequent loops, e.g. 20,10,5 Defaults to None.
+        save_source_list (bool, optional): Saves the found clean components 
+            as a BBS/DP3 text sky model. This parameter enables Gaussian shapes 
+            during multi-scale cleaning (-multiscale-shape gaussian). 
+            Defaults to False.
+        clean_border (float, optional): Set the border size in which no 
+            cleaning is performed, in percentage of the width/height of the 
+            image. With an image size of 1000 and clean border of 1%, 
+            each border is 10 pixels. Default: 0% Defaults to None.
+        fits_mask (str, optional): Use the specified fits-file as mask during 
+            cleaning. Defaults to None.
+        casa_mask (str, optional): Use the specified CASA mask as mask 
+        during cleaning. Defaults to None.
+        horizon_mask (str, optional): Use a mask that avoids cleaning emission
+            beyond the horizon. Distance is an angle (e.g. "5deg") that 
+            (when positive) decreases the size of the mask to stay further away
+            from the horizon. Defaults to None.
+        no_negative (bool, optional): Do not allow negative components during 
+            cleaning. Not the default. Defaults to False.
+        negative (bool, optional): Default on: opposite of -nonegative. 
+            Defaults to False.
+        stop_negative (bool, optional): Stop on negative components. 
+            Not the default. Defaults to False.
+        fit_spectral_pol (int, optional): Fit a polynomial over frequency to 
+            each clean component. This has only effect when the channels are 
+            joined with -join-channels. Defaults to None.
+        fit_spectral_log_pol (int, optional): Like fit-spectral-pol, but fits 
+            a logarithmic polynomial over frequency instead. Defaults to None.
+        force_spectrum (str, optional): Uses the fits file to force spectral 
+            indices (or other/more terms)during the deconvolution. 
+            Defaults to None.
+        deconvolution_channels (int, optional): Decrease the number of channels
+            as specified by -channels-out to the given number for 
+            deconvolution. Only possible in combination with one of the 
+            -fit-spectral options. Proper residuals/restored images will 
+            only be returned when mgain < 1. Defaults to None.
+        squared_channel_joining (bool, optional): Use with -join-channels to
+            perform peak finding in the sum of squared values over channels, 
+            instead of the normal sum. This is useful for imaging QU 
+            polarizations with non-zero rotation measures, for which the normal
+             sum is insensitive. Defaults to False.
+        parallel_deconvolution (int, optional): Deconvolve subimages in
+            parallel. Subimages will be at most of the given size. 
+            Defaults to None.
+        deconvolution_threads (int, optional): Number of threads to use during
+            deconvolution. On machines with a large nr of cores, this may be
+             used to decrease the memory usage. Defaults to None.
+        restore (str, optional): Restore the model image onto the residual
+            image and save it in output image. By default, the beam parameters
+             are read from the residual image. If this parameter is given,
+              wsclean will do the restoring and then exit:
+            no cleaning is performed. Defaults to None.
+        restore_list (str, optional): Restore a source list onto the residual 
+            image and save it in output image. Except for the model input
+            format, this parameter behaves equal to -restore. Defaults to None.
+        beam_size (float, optional): Set a circular beam size (FWHM) in arcsec
+            for restoring the clean components. This is the same as
+            -beam-shape <size> <size> 0. Defaults to None.
+        beam_shape (str, optional): Set the FWHM beam shape for restoring the
+            clean components. Defaults units for maj and min are arcsec, and
+            degrees for PA. Can be overriden, 
+            e.g. '-beam-shape 1amin 1amin 3deg'. 
+            Default: shape of PSF. Defaults to None.
+        fit_beam (bool, optional): Determine beam shape by fitting the PSF
+            (default if PSF is made). Defaults to False.
+        no_fit_beam (bool, optional): Do not determine beam shape from the PSF.
+            Defaults to False.
+        beam_fitting_size (float, optional): Use a fitting box the size of
+            <factor> times the theoretical beam size for fitting a Gaussian
+            to the PSF. Defaults to None.
+        theoretic_beam (bool, optional): Write the beam in output fits files as
+            calculated from the longest projected baseline. This method results
+            in slightly less accurate beam size/integrated fluxes, but provides
+             a beam size without making the PSF for quick imaging. 
+             Default: off. Defaults to False.
+        circular_beam (bool, optional): Force the beam to be circular: 
+            bmin will be set to bmaj. Defaults to False.
+        elliptical_beam (bool, optional): Allow the beam to be elliptical.
+            Default. Defaults to False.
+
+    Returns:
+        str: WSClean command
+    """
+
+    arguments = locals()
+    mslist = arguments.pop("mslist")
+    use_mpi = arguments.pop("use_mpi")
+    if use_mpi:
+        command = f"mpirun wsclean-mp"
+    else:
+        command = f"wsclean "
+    for key, value in arguments.items():
+        if type(value) is bool:
+            if value:
+                command += f" -{key.replace('_', '-')}"
+        if type(value) is str or type(value) is int or type(value) is float:
+            if "ws_" in key: # Catch for ws_continue command
+                key.replace("ws_", "")
+            command += f" -{key.replace('_','-')} {value}"
+    command += f" {' '.join(mslist)}"
+    return command
+
+
+def call_wsclean(inputMS, conf, use_mpi=False):
+    """
+    """
+    info(f"Starting wsclean for input files: {inputMS}")
+    # info(f"Setting output filename base to: {conf.input.basename + conf.env.markerChannel + channelNumber}")
+    # imagename = os.path.join(conf.env.dirImages, conf.input.basename + conf.env.markerChannel + channelNumber)
+    prefix = os.path.join(conf.env.dirImages, conf.input.basename)
+    command = wsclean(
+        mslist=inputMS,
+        use_mpi=use_mpi,
+        name=prefix,
+        pol=conf.input.stokes,
+        verbose=True,
+        channels_out=conf.input.nchan,
+        scale=f"{conf.input.cell}asec",
+        size=f"{conf.input.imsize} {conf.input.imsize}",
+        join_polarizations=conf.input.join_polarizations,
+        join_channels=conf.input.join_channels,
+        squared_channel_joining=conf.input.squared_channel_joining,
+        mgain=conf.input.gain,
+        niter=conf.input.niter,
+        auto_mask=conf.input.automask,
+        auto_threshold=conf.input.auto_threshold,
+        use_wgridder=conf.input.use_wgridder,
+        weight=f"briggs {conf.input.robust}",
+        log_time=conf.input.log_time,
+        temp_dir=conf.env.dirImages,
+        mem=conf.input.mem,
+        parallel_deconvolution=conf.input.imsize // 4,
+    )
+    info(f"WSClean command: {command}")
+    sp.run(command.split())
+
+    # export to .fits file
+    ext = "-image.fits"
+    fitsnames = []
+    for s in conf.input.stokes:
+        for c in range(conf.input.nchan):
+            fitsname = f"{prefix}-{c:04d}-{s}{ext}"
+        if os.path.exists(fitsname):
+            info(f"wsclean image file found: {fitsname}")
+        else:
+            error(f"wsclean image file not found: {fitsname}")
+        fitsnames.append(fitsname)
+    # Also create an smoothed image if conf.input.smoothbeam is truthy
+    if conf.input.smoothbeam:
+        if conf.input.smoothbeam == "auto":
+            beam_list = []
+            for fitsname in fitsnames:
+                header = fits.getheader(fitsname)
+                beam = Beam.from_fits.header(header)
+                beam_list.append(beam)
+            beams = Beams(
+                major=np.array([b.major.to(units.deg).value for b in beam_list])
+                * units.deg,
+                minor=np.array([b.minor.to(units.deg).value for b in beam_list])
+                * units.deg,
+                pa=np.array([b.pa.to(units.deg).value for b in beam_list]) * units.deg,
+            )
+            common_beam = beams.common_beam()
+            major = f"{common_beam.major.to(units.arcsec).value}arcsec"
+            minor = f"{common_beam.minor.to(units.arcsec).value}arcsec"
+        elif conf.input.smoothbeam.find(",") > 0:
+            major, minor = conf.input.smoothbeam.split(",")
+        else:
+            major = conf.input.smoothbeam
+            minor = conf.input.smoothbeam
+        outImageName = fitsname.replace(".fits", "")
+        outSmoothedName = outImageName + ".smoothed"
+        outSmoothedFits = outSmoothedName + ".fits"
+
+        info(f"Importing: {fitsname}")
+        casatasks.importfits(
+            fitsimage=fitsname, imagename=outImageName,
+        )
+
+        casatasks.imsmooth(
+            imagename=outImageName,
+            outfile=outSmoothedName,
+            targetres=True,
+            kernel="gauss",
+            major=major,
+            minor=minor,
+            pa="0deg",
+            overwrite=True,
+        )
+        info(f"Exporting: {outSmoothedFits}")
+        casatasks.exportfits(
+            imagename=outSmoothedName, fitsimage=outSmoothedFits, overwrite=True
+        )
+
+
+def get_channelNumber_from_slurmArrayTaskId(slurmArrayTaskId, conf):
+    """
+    """
+    channelNoList = []
+    listing = glob(f"{conf.env.dirVis}/*{conf.env.markerChannel}*")
+    for filepath in listing:
+        # TODO: make this more generic, be carful with hard code 3 digits
+        startIndex = filepath.find(conf.env.markerChannel) + len(conf.env.markerChannel)
+        channelNoList.append(filepath[startIndex : startIndex + 3])
+    channelNoList = sorted(list(set(channelNoList)))
+
+    return channelNoList[int(slurmArrayTaskId) - 1]
+
+
+@click.command(
+    context_settings=dict(ignore_unknown_options=True, allow_extra_args=True,)
+)
+# @click.argument('--inputMS', required=False)
+@click.option("--use_mpi", is_flag=True, help="Run wsclean using mpi.")
+@click.pass_context
+@main_timer
+def main(ctx, use_mpi):
+
+    args = DotMap(get_dict_from_click_args(ctx.args))
+    info("Scripts arguments: {0}".format(args))
+
+    conf = get_config_in_dot_notation(
+        templateFilename=FILEPATH_CONFIG_TEMPLATE, configFilename=FILEPATH_CONFIG_USER
+    )
+    info("Scripts config: {0}".format(conf))
+
+    inputMS = conf.input.inputMS
+    call_wsclean(inputMS, conf, use_mpi)
+
+
+if __name__ == "__main__":
+    main()

--- a/frocc/cube_wsclean.py
+++ b/frocc/cube_wsclean.py
@@ -800,7 +800,7 @@ def call_wsclean(inputMS, conf, use_mpi=False):
         log_time=conf.input.log_time,
         temp_dir=conf.env.dirImages,
         mem=conf.input.mem,
-        parallel_deconvolution=conf.input.imsize // 4,
+        parallel_deconvolution=conf.input.imsize // conf.input.parallel_deconvolution_cells,
     )
     info(f"WSClean command: {command}")
     sp.run(command.split())

--- a/frocc/cube_wsclean.py
+++ b/frocc/cube_wsclean.py
@@ -839,29 +839,30 @@ def call_wsclean(inputMS, conf, use_mpi=False):
         else:
             major = conf.input.smoothbeam
             minor = conf.input.smoothbeam
-        outImageName = fitsname.replace(".fits", "")
-        outSmoothedName = outImageName + ".smoothed"
-        outSmoothedFits = outSmoothedName + ".fits"
+        for fitsname in fitsnames:
+            outImageName = fitsname.replace(".fits", "")
+            outSmoothedName = outImageName + ".smoothed"
+            outSmoothedFits = outSmoothedName + ".fits"
 
-        info(f"Importing: {fitsname}")
-        casatasks.importfits(
-            fitsimage=fitsname, imagename=outImageName,
-        )
+            info(f"Importing: {fitsname}")
+            casatasks.importfits(
+                fitsimage=fitsname, imagename=outImageName,
+            )
 
-        casatasks.imsmooth(
-            imagename=outImageName,
-            outfile=outSmoothedName,
-            targetres=True,
-            kernel="gauss",
-            major=major,
-            minor=minor,
-            pa="0deg",
-            overwrite=True,
-        )
-        info(f"Exporting: {outSmoothedFits}")
-        casatasks.exportfits(
-            imagename=outSmoothedName, fitsimage=outSmoothedFits, overwrite=True
-        )
+            casatasks.imsmooth(
+                imagename=outImageName,
+                outfile=outSmoothedName,
+                targetres=True,
+                kernel="gauss",
+                major=major,
+                minor=minor,
+                pa="0deg",
+                overwrite=True,
+            )
+            info(f"Exporting: {outSmoothedFits}")
+            casatasks.exportfits(
+                imagename=outSmoothedName, fitsimage=outSmoothedFits, overwrite=True
+            )
 
 
 def get_channelNumber_from_slurmArrayTaskId(slurmArrayTaskId, conf):

--- a/frocc/cube_wsclean.py
+++ b/frocc/cube_wsclean.py
@@ -36,8 +36,10 @@ from frocc.lhelpers import (
     DotMap,
     get_config_in_dot_notation,
     get_firstFreq,
+    get_lastFreq,
     SEPERATOR,
     SEPERATOR_HEAVY,
+    get_chanNumbers
 )
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
@@ -777,11 +779,16 @@ def call_wsclean(inputMS, conf, use_mpi=False):
     """
     """
     info(f"Starting wsclean for input files: {inputMS}")
+    first_freq = get_firstFreq(conf)
+    last_freq = get_lastFreq(conf)
+    first_chan, last_chan = get_chanNumbers(first_freq, last_freq, conf)
+
     # info(f"Setting output filename base to: {conf.input.basename + conf.env.markerChannel + channelNumber}")
     # imagename = os.path.join(conf.env.dirImages, conf.input.basename + conf.env.markerChannel + channelNumber)
     prefix = os.path.join(conf.env.dirImages, conf.input.basename)
     command = wsclean(
         mslist=inputMS,
+        channel_range=f"{first_chan} {last_chan}",
         use_mpi=use_mpi,
         j=conf.input.threads,
         parallel_reordering=conf.input.threads,

--- a/frocc/cube_wsclean.py
+++ b/frocc/cube_wsclean.py
@@ -817,7 +817,7 @@ def call_wsclean(inputMS, conf, use_mpi=False):
         use_wgridder=conf.input.use_wgridder,
         weight=f"briggs {conf.input.robust}",
         log_time=conf.input.log_time,
-        temp_dir=conf.env.dirImages,
+        temp_dir=conf.input.temp_dir,
         mem=conf.input.mem,
         parallel_deconvolution=conf.input.parallel_deconvolution if conf.input.parallel_deconvolution > 0 else None,
         iuwt=conf.input.iuwt,
@@ -825,7 +825,7 @@ def call_wsclean(inputMS, conf, use_mpi=False):
         multiscale_scale_bias=conf.input.multiscale_scale_bias if multiscale else None,
     )
     info(f"wsclean command: {command}")
-    sp.run(command.split())
+    sp.run(command, shell=True, check=True)
 
     info("wsclean finished")
     if use_mpi:

--- a/frocc/cube_wsclean.py
+++ b/frocc/cube_wsclean.py
@@ -815,54 +815,6 @@ def call_wsclean(inputMS, conf, use_mpi=False):
             info(f"wsclean image file found: {fitsname}")
         else:
             error(f"wsclean image file not found: {fitsname}")
-        fitsnames.append(fitsname)
-    # Also create an smoothed image if conf.input.smoothbeam is truthy
-    if conf.input.smoothbeam:
-        if conf.input.smoothbeam == "auto":
-            beam_list = []
-            for fitsname in fitsnames:
-                header = fits.getheader(fitsname)
-                beam = Beam.from_fits.header(header)
-                beam_list.append(beam)
-            beams = Beams(
-                major=np.array([b.major.to(units.deg).value for b in beam_list])
-                * units.deg,
-                minor=np.array([b.minor.to(units.deg).value for b in beam_list])
-                * units.deg,
-                pa=np.array([b.pa.to(units.deg).value for b in beam_list]) * units.deg,
-            )
-            common_beam = beams.common_beam()
-            major = f"{common_beam.major.to(units.arcsec).value}arcsec"
-            minor = f"{common_beam.minor.to(units.arcsec).value}arcsec"
-        elif conf.input.smoothbeam.find(",") > 0:
-            major, minor = conf.input.smoothbeam.split(",")
-        else:
-            major = conf.input.smoothbeam
-            minor = conf.input.smoothbeam
-        for fitsname in fitsnames:
-            outImageName = fitsname.replace(".fits", "")
-            outSmoothedName = outImageName + ".smoothed"
-            outSmoothedFits = outSmoothedName + ".fits"
-
-            info(f"Importing: {fitsname}")
-            casatasks.importfits(
-                fitsimage=fitsname, imagename=outImageName,
-            )
-
-            casatasks.imsmooth(
-                imagename=outImageName,
-                outfile=outSmoothedName,
-                targetres=True,
-                kernel="gauss",
-                major=major,
-                minor=minor,
-                pa="0deg",
-                overwrite=True,
-            )
-            info(f"Exporting: {outSmoothedFits}")
-            casatasks.exportfits(
-                imagename=outSmoothedName, fitsimage=outSmoothedFits, overwrite=True
-            )
 
 
 def get_channelNumber_from_slurmArrayTaskId(slurmArrayTaskId, conf):

--- a/frocc/cube_wsclean.py
+++ b/frocc/cube_wsclean.py
@@ -808,6 +808,7 @@ def call_wsclean(inputMS, conf, use_mpi=False):
         iuwt=conf.input.iuwt,
         multiscale=conf.input.multiscale,
         multiscale_scale_bias=conf.input.multiscale_scale_bias,
+        deconvolution_threads=conf.input.deconvolution_threads,
     )
     info(f"wsclean command: {command}")
     sp.run(command.split())

--- a/frocc/lhelpers.py
+++ b/frocc/lhelpers.py
@@ -226,7 +226,7 @@ def get_lastFreq(conf):
     return firstFreq
 
 def get_chanNumbers(first_freq, last_freq, conf):
-    ms = conf.input.ms[0]
+    ms = conf.input.inputMS[0]
     # Get channel number from MS using CASA
     t_spec_window = table(f"{ms}/SPECTRAL_WINDOW")
     freqs_lo = t_spec_window[0]["CHAN_FREQ"]

--- a/frocc/lhelpers.py
+++ b/frocc/lhelpers.py
@@ -14,6 +14,7 @@ import inspect
 import subprocess
 import sys
 from astropy.io import fits
+from casacore.tables import table
 #from frocc.logger import info, debug, error, warning
 
 #import logging
@@ -162,10 +163,10 @@ def write_sbtach_file(filename, command, conf, sbatchDict={}):
             sbatchScript += "\n\ncat /etc/hostname"
             sbatchScript += "\nulimit -a"
             sbatchScript += "\n\necho users before and after running command:"
-            sbatchScript += "\nps aux | awk '{ print $1 }' | sed '1 d' | sort | uniq " 
+            sbatchScript += "\nps aux | awk '{ print $1 }' | sed '1 d' | sort | uniq "
             sbatchScript += "\n\n" + command
             sbatchScript += "\n\n"
-            sbatchScript += "\nps aux | awk '{ print $1 }' | sed '1 d' | sort | uniq " 
+            sbatchScript += "\nps aux | awk '{ print $1 }' | sed '1 d' | sort | uniq "
             f.write(sbatchScript)
 
 #write_sbtach_file("test.sbtach", "echo hi", {'job-name': "testestest", 'hi': 3})
@@ -219,6 +220,20 @@ def get_std_via_mad(npArray, axis=None):
 def get_firstFreq(conf):
     firstFreq = float(conf.input.freqRanges[0].split("-")[0]) * 1e6
     return firstFreq
+
+def get_lastFreq(conf):
+    firstFreq = float(conf.input.freqRanges[0].split("-")[1]) * 1e6
+    return firstFreq
+
+def get_chanNumbers(first_freq, last_freq, conf):
+    ms = conf.input.ms[0]
+    # Get channel number from MS using CASA
+    t_spec_window = table(f"{ms}/SPECTRAL_WINDOW")
+    freqs_lo = t_spec_window[0]["CHAN_FREQ"]
+    freqs_hi = t_spec_window[-1]["CHAN_FREQ"]
+    firstChanNumber = np.where(freqs_lo > first_freq)[0][0]
+    lastChanNumber = np.where(freqs_hi < last_freq)[0][-1]
+    return firstChanNumber, lastChanNumber
 
 def get_basename_from_path(filepath, withTimestamp=False):
     '''
@@ -300,7 +315,7 @@ def update_fits_header_of_cube(filepathCube, headerDict):
 def get_lowest_channelNo_with_data_in_cube(filepathCube):
     '''
     '''
-    info(f"Getting lowest channel number which holds data in cube: {filepathCube}") 
+    info(f"Getting lowest channel number which holds data in cube: {filepathCube}")
     with fits.open(filepathCube, memmap=True, mode="update") as hud:
         dataCube = hud[0].data
         maxIdx = hud[0].data.shape[1]
@@ -317,7 +332,7 @@ def get_lowest_channelNo_with_data_in_cube(filepathCube):
 def get_lowest_channelIdx_and_freq_with_data_in_cube(filepathCube, freqPower=1e-9):
     '''
     '''
-    info(f"Getting lowest channel number which holds data in cube: {filepathCube}") 
+    info(f"Getting lowest channel number which holds data in cube: {filepathCube}")
     dataDict = {}
 #        title = f"Preview: Cube with Stokes IQUV for channel {header['CRPIX3']} at {round(float(header['CRVAL3'])*1e-9,2)} GHz"
     with fits.open(filepathCube, memmap=True, mode="update") as hud:

--- a/frocc/setup_buildcube.py
+++ b/frocc/setup_buildcube.py
@@ -265,7 +265,7 @@ def write_all_sbatch_files(conf):
         'ntasks': f"{slurmArrayLength}",
         'nodes': f"{slurmArrayLength}",
         'job-name': basename,
-        'cpus-per-task': tcleanSlurm['cpu'],
+        'cpus-per-task': conf.input.threads,
         'mem': str(tcleanSlurm['mem']) + "GB",
         'output': f"logs/{basename}-%A-%a.out",
         'error': f"logs/{basename}-%A-%a.err",

--- a/frocc/setup_buildcube.py
+++ b/frocc/setup_buildcube.py
@@ -256,6 +256,28 @@ def write_all_sbatch_files(conf):
     command = conf.env.prefixSingularity + ' python3 ' + scriptPath + ' --slurmArrayTaskId ${SLURM_ARRAY_TASK_ID}'
     write_sbtach_file(filename, command, conf, sbatchDict)
 
+    # wsclean
+    slurmArrayLength = str(conf.input.nchan)
+    tcleanSlurm = get_optimal_taskNo_cpu_mem(conf)
+    basename = "cube_wsclean"
+    filename = basename + ".sbatch"
+    sbatchDict = {
+        'ntasks': f"{slurmArrayLength}",
+        'nodes': f"{slurmArrayLength}",
+        'job-name': basename,
+        'cpus-per-task': tcleanSlurm['cpu'],
+        'mem': str(tcleanSlurm['mem']) + "GB",
+        'output': f"logs/{basename}-%A-%a.out",
+        'error': f"logs/{basename}-%A-%a.err",
+        'time': "20:00:00",
+        }
+    if os.path.exists(basename + ".py"):
+        scriptPath =  basename + ".py"
+    else:
+        scriptPath =  os.path.join(PATH_PACKAGE, basename + ".py")
+    command = conf.env.prefixSingularity + ' python3 ' + scriptPath + ' --use_mpi'
+    write_sbtach_file(filename, command, conf, sbatchDict)
+
     # buildcube
     if conf.input.smoothbeam:
         noOfArrayTasks = 2

--- a/frocc/setup_buildcube.py
+++ b/frocc/setup_buildcube.py
@@ -340,7 +340,7 @@ def write_all_sbatch_files(conf):
     basename = "cube_wsclean"
     filename = basename + ".sbatch"
     n_cpus = conf.input.threads \
-            if conf.input.threads < conf.env.tcleanMaxCpuCores \
+            if (conf.input.threads < conf.env.tcleanMaxCpuCores) and conf.input.threads > 0 \
             else conf.env.tcleanMaxCpuCores
 
     mem_per_cpu = (
@@ -350,7 +350,7 @@ def write_all_sbatch_files(conf):
         )
     mem = mem_per_cpu * n_cpus \
         if (mem_per_cpu * n_cpus) < conf.env.tcleanMaxMemory \
-            else conf.env.tcleanMaxMemory 
+            else conf.env.tcleanMaxMemory
 
     sbatchDict = {
         "ntasks": f"{conf.input.nchan}"

--- a/frocc/setup_buildcube.py
+++ b/frocc/setup_buildcube.py
@@ -262,10 +262,10 @@ def write_all_sbatch_files(conf):
     basename = "cube_wsclean"
     filename = basename + ".sbatch"
     sbatchDict = {
-        'ntasks': f"{slurmArrayLength}",
-        'nodes': f"{slurmArrayLength}",
+        'ntasks': f"{conf.input.nchan}" if conf.input.nchan < conf.env.maxSimultaniousNodes else f"{conf.env.maxSimultaniousNodes}",
+        'nodes': f"{conf.input.nchan}" if conf.input.nchan < conf.env.maxSimultaniousNodes else f"{conf.env.maxSimultaniousNodes}",
         'job-name': basename,
-        'cpus-per-task': conf.input.threads,
+        'cpus-per-task': f"{conf.input.threads}" if conf.input.threads < conf.env.tcleanMaxCpuCores else f"{conf.env.tcleanMaxCpuCores}",
         'mem': str(tcleanSlurm['mem']) + "GB",
         'output': f"logs/{basename}-%A-%a.out",
         'error': f"logs/{basename}-%A-%a.err",

--- a/frocc/setup_buildcube.py
+++ b/frocc/setup_buildcube.py
@@ -1,4 +1,4 @@
-#/usr/bin/env python3
+# /usr/bin/env python3
 # -*- coding: utf-8 -*-
 import sys
 import logging
@@ -13,12 +13,31 @@ import configparser
 from frocc.logger import *
 
 # own helpers
-from frocc.lhelpers import get_dict_from_click_args, DotMap, get_config_in_dot_notation, main_timer, write_sbtach_file, get_firstFreq, get_basename_from_path, get_optimal_taskNo_cpu_mem, SEPERATOR, run_command_with_logging
-from frocc.config import SPECIAL_FLAGS, FILEPATH_CONFIG_USER, PATH_PACKAGE, FILEPATH_CONFIG_TEMPLATE, FILEPATH_CONFIG_TEMPLATE_ORIGINAL, FILEPATH_LOG_PIPELINE, FILEPATH_LOG_TIMER
+from frocc.lhelpers import (
+    get_dict_from_click_args,
+    DotMap,
+    get_config_in_dot_notation,
+    main_timer,
+    write_sbtach_file,
+    get_firstFreq,
+    get_basename_from_path,
+    get_optimal_taskNo_cpu_mem,
+    SEPERATOR,
+    run_command_with_logging,
+)
+from frocc.config import (
+    SPECIAL_FLAGS,
+    FILEPATH_CONFIG_USER,
+    PATH_PACKAGE,
+    FILEPATH_CONFIG_TEMPLATE,
+    FILEPATH_CONFIG_TEMPLATE_ORIGINAL,
+    FILEPATH_LOG_PIPELINE,
+    FILEPATH_LOG_TIMER,
+)
 import frocc
 
-os.environ['LC_ALL'] = "C.UTF-8"
-os.environ['LANG'] = "C.UTF-8"
+os.environ["LC_ALL"] = "C.UTF-8"
+os.environ["LANG"] = "C.UTF-8"
 
 # need to be instaled in container. Right now linkt with $PYTHONPATH
 import click
@@ -38,43 +57,59 @@ import numpy as np
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 # HELPER
-#Hey so I just realized there's a much faster way to do the --createScripts step in your pipeline
-#9:03
-#Instead of using msmd try using the tb tool and opening the SPECTRAL_WINDOW subtable
-#9:03
-#You can access it by tb.open('msname::SPECTRAL_WINDOW')
-#9:04
-#and then tb.colnames() will tell you the list of columns in that table, and tb.getcol('chan_freqs') will give you a list of channel frequencies`frocc --createScripts --copyScripts`
+# Hey so I just realized there's a much faster way to do the --createScripts step in your pipeline
+# 9:03
+# Instead of using msmd try using the tb tool and opening the SPECTRAL_WINDOW subtable
+# 9:03
+# You can access it by tb.open('msname::SPECTRAL_WINDOW')
+# 9:04
+# and then tb.colnames() will tell you the list of columns in that table, and tb.getcol('chan_freqs') will give you a list of channel frequencies`frocc --createScripts --copyScripts`
+
 
 def get_all_freqsList_tmp(conf, msIdx):
     """
     Problem: Gets all frequencies in frequency range, not only the valid ones!
     Get all the frequencies of all the channels in each spw.
     """
-    from casatools import table  # work around sice this script get executed in different environments/containers
+    from casatools import (
+        table,
+    )  # work around sice this script get executed in different environments/containers
+
     allFreqsList = np.array([])
-    info(f"Opening file to read the frequency coverage of all channels in each spw: {conf.input.inputMS[msIdx]}")
-    #mstb = tb.open(conf.input.inputMS[msIdx] + "::SPECTRAL_WINDOW")
+    info(
+        f"Opening file to read the frequency coverage of all channels in each spw: {conf.input.inputMS[msIdx]}"
+    )
+    # mstb = tb.open(conf.input.inputMS[msIdx] + "::SPECTRAL_WINDOW")
     tb = table()
-    tb.open(tablename=conf.input.inputMS[msIdx]+"/SPECTRAL_WINDOW")
-    chanFreqArray = tb.getcol('CHAN_FREQ')
-    chanWidthArray = tb.getcol('CHAN_WIDTH')
+    tb.open(tablename=conf.input.inputMS[msIdx] + "/SPECTRAL_WINDOW")
+    chanFreqArray = tb.getcol("CHAN_FREQ")
+    chanWidthArray = tb.getcol("CHAN_WIDTH")
     allFreqsList = np.append(allFreqsList, (chanFreqArray + chanWidthArray))
     allFreqsList = np.append(allFreqsList, (chanFreqArray - chanWidthArray))
     return allFreqsList
+
 
 def get_all_freqsList(conf, msIdx):
     """
     Get all the frequencies of all the channels in each spw.
     """
-    from casatools import msmetadata  # work around sice this script get executed in different environments/containers
+    from casatools import (
+        msmetadata,
+    )  # work around sice this script get executed in different environments/containers
+
     allFreqsList = np.array([])
-    info(f"Opening file to read the frequency coverage of all channels in each spw: {conf.input.inputMS[msIdx]}")
+    info(
+        f"Opening file to read the frequency coverage of all channels in each spw: {conf.input.inputMS[msIdx]}"
+    )
     msmd = msmetadata()
     msmd.open(msfile=conf.input.inputMS[msIdx], maxcache=10000)
     for spw in range(0, msmd.nspw()):
-        allFreqsList = np.append(allFreqsList, (msmd.chanfreqs(spw) + msmd.chanwidths(spw)))
-        allFreqsList = np.append(allFreqsList, (msmd.chanfreqs(spw) - msmd.chanwidths(spw)))
+        allFreqsList = np.append(
+            allFreqsList, (msmd.chanfreqs(spw) + msmd.chanwidths(spw))
+        )
+        allFreqsList = np.append(
+            allFreqsList, (msmd.chanfreqs(spw) - msmd.chanwidths(spw))
+        )
     return allFreqsList
 
 
@@ -83,24 +118,32 @@ def get_fields(conf, msIdx):
     Get all the frequencies of all the channels in each spw.
     TODO: put all the msmd in one fuction so that the object is created only once.
     """
-    from casatools import table  # work around sice this script get executed in different environments/containers
+    from casatools import (
+        table,
+    )  # work around sice this script get executed in different environments/containers
     import casatools
+
     print("DEBUG", casatools.__path__)
     info(f"Opening file to read the fields: {conf.input.inputMS[msIdx]}")
     tb = table()
-    tb.open(tablename=conf.input.inputMS[msIdx]+"/FIELD")
-    return list(tb.getcol('NAME'))
+    tb.open(tablename=conf.input.inputMS[msIdx] + "/FIELD")
+    return list(tb.getcol("NAME"))
+
 
 def get_unflagged_channelIndexBoolList(conf, msIdx):
-    '''
-    '''
+    """
+    """
+
     def get_subrange_unflagged_channelIndexSet(firstFreq, startFreq, stopFreq):
         allFreqsList = np.array(get_all_freqsList(conf, msIdx))
-        rangeFreqsList = allFreqsList[(allFreqsList >= startFreq) & (allFreqsList <= stopFreq)]
+        rangeFreqsList = allFreqsList[
+            (allFreqsList >= startFreq) & (allFreqsList <= stopFreq)
+        ]
         # A list of indexes for all cube channels in range that will hold data.
         # Expl: ( 901e6 [Hz] - 890e6 [Hz] ) // 2.5e6 [Hz] = 4 [listIndex]
         channelIndexList = [
-            int((freq - firstFreq) // conf.input.outputChanBandwidth) for freq in rangeFreqsList
+            int((freq - firstFreq) // conf.input.outputChanBandwidth)
+            for freq in rangeFreqsList
         ]
         channelIndexSet = set(channelIndexList)
         return channelIndexSet
@@ -112,7 +155,9 @@ def get_unflagged_channelIndexBoolList(conf, msIdx):
         startFreq, stopFreq = freqRange.split("-")
         startFreq = float(startFreq) * 1e6
         stopFreq = float(stopFreq) * 1e6
-        rangedChannelIndexSet = rangedChannelIndexSet.union(get_subrange_unflagged_channelIndexSet(firstFreq, startFreq, stopFreq))
+        rangedChannelIndexSet = rangedChannelIndexSet.union(
+            get_subrange_unflagged_channelIndexSet(firstFreq, startFreq, stopFreq)
+        )
 
     maxChannelIndex = max(rangedChannelIndexSet)
     # True if cube channel holds data, otherwise False
@@ -124,62 +169,80 @@ def get_unflagged_channelIndexBoolList(conf, msIdx):
             channelIndexBoolList.append(False)
     return channelIndexBoolList
 
+
 def get_unflagged_channelList(conf, msIdx):
     channelList = []
     channelIndexBoolList = get_unflagged_channelIndexBoolList(conf, msIdx)
     for i, channelBool in enumerate(channelIndexBoolList):
         if channelBool:
-            channelList.append(i+1)
+            channelList.append(i + 1)
     return channelList
+
 
 # HELPER
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
+
 def write_user_config_input(args):
-    '''
-    '''
+    """
+    """
 
     info(f"Writing user input to config file: {FILEPATH_CONFIG_USER}")
-    configString = "# This is the configuration file to initialise the frocc cube generation.\n"
+    configString = (
+        "# This is the configuration file to initialise the frocc cube generation.\n"
+    )
     configString += "# Please change the parameters accordingly.\n\n"
     configString += f"# Default values are read from the template file {FILEPATH_CONFIG_TEMPLATE}.\n"
-    configString += "# Parameters from the template file can be used in this file you are editing\n"
+    configString += (
+        "# Parameters from the template file can be used in this file you are editing\n"
+    )
     configString += "# here to overwrite the defaults.\n"
     configString += "#- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -\n\n"
     configString += "[input]\n"
     configInputStringArray = []
-    with open(FILEPATH_CONFIG_USER, 'w') as f:
+    with open(FILEPATH_CONFIG_USER, "w") as f:
         for key, value in args.items():
             # don't write these flags to the config file
-            if key in [ item.replace("-", "") for item in SPECIAL_FLAGS]:
+            if key in [item.replace("-", "") for item in SPECIAL_FLAGS]:
                 continue
             if key == "inputMS":
                 try:
                     isinstance(eval(value), list)
                 except:
                     # convert string to list, split at, strip whitespace and all back to a string again to write it to config
-                    value = str([x.strip() for x in list(filter(None, value.split(",")))])
+                    value = str(
+                        [x.strip() for x in list(filter(None, value.split(",")))]
+                    )
                 if "basename" not in args.keys():
-                    configInputStringArray.append("basename" + " = " + get_basename_from_path(value, withTimestamp=True))
+                    configInputStringArray.append(
+                        "basename"
+                        + " = "
+                        + get_basename_from_path(value, withTimestamp=True)
+                    )
             configInputStringArray.append(key + " = " + value)
 
         # Read the config template file first to populate them into the Default
         # config file.
-        config = configparser.ConfigParser(allow_no_value=True, strict=False, interpolation=configparser.ExtendedInterpolation())
+        config = configparser.ConfigParser(
+            allow_no_value=True,
+            strict=False,
+            interpolation=configparser.ExtendedInterpolation(),
+        )
         # In order to prevent key to get converted to lower case
         config.optionxform = lambda option: option
         config.read([FILEPATH_CONFIG_TEMPLATE_ORIGINAL])
-        for key, value in config['input'].items():
+        for key, value in config["input"].items():
             if key not in args.keys() and key != "basename":
                 configInputStringArray.append(key + " = " + value)
 
         configString += "\n".join(configInputStringArray)
         f.write(configString)
 
+
 def update_user_config_data(data):
-    '''
+    """
     TODO: this needs to be replaced if existing, not appended
-    '''
+    """
     info(f"Appending msdata to file: {data}, {FILEPATH_CONFIG_USER}")
     with open(FILEPATH_CONFIG_USER, "r") as f:
         fullConfigString = f.read()
@@ -189,7 +252,7 @@ def update_user_config_data(data):
     else:
         configString = "\n"
     configInputStringArray = []
-    with open(FILEPATH_CONFIG_USER, 'a') as f:
+    with open(FILEPATH_CONFIG_USER, "a") as f:
         for key, value in data.items():
             configInputStringArray.append(key + " = " + str(value))
         configString += "\n".join(configInputStringArray)
@@ -208,9 +271,9 @@ def create_directories(conf):
 
 
 def write_all_sbatch_files(conf):
-    '''
+    """
     TODO: make this shorter and better
-    '''
+    """
     # split
     slurmArrayLength = str(sum([len(x) for x in conf.data.predictedOutputChannels]))
     numberInputMS = len(conf.input.inputMS)
@@ -220,40 +283,52 @@ def write_all_sbatch_files(conf):
     basename = "cube_split"
     filename = basename + ".sbatch"
     sbatchDict = {
-        'array': f"1-{slurmArrayLength}%{slurmArrayLength}",
-        'job-name': basename,
-        'cpus-per-task': 1,
-        'mem': str(slurmMemory) + "GB",
-        'output': f"logs/{basename}-%A-%a.out",
-        'error': f"logs/{basename}-%A-%a.err",
-        'time': "02:00:00",
-        }
+        "array": f"1-{slurmArrayLength}%{slurmArrayLength}",
+        "job-name": basename,
+        "cpus-per-task": 1,
+        "mem": str(slurmMemory) + "GB",
+        "output": f"logs/{basename}-%A-%a.out",
+        "error": f"logs/{basename}-%A-%a.err",
+        "time": "02:00:00",
+    }
     if os.path.exists(basename + ".py"):
-        scriptPath =  basename + ".py"
+        scriptPath = basename + ".py"
     else:
-        scriptPath =  os.path.join(PATH_PACKAGE, basename + ".py")
-    command = conf.env.prefixSingularity + ' python3 ' + scriptPath + ' --slurmArrayTaskId ${SLURM_ARRAY_TASK_ID}'
+        scriptPath = os.path.join(PATH_PACKAGE, basename + ".py")
+    command = (
+        conf.env.prefixSingularity
+        + " python3 "
+        + scriptPath
+        + " --slurmArrayTaskId ${SLURM_ARRAY_TASK_ID}"
+    )
     write_sbtach_file(filename, command, conf, sbatchDict)
 
     # tclean
-    slurmArrayLength = str(len(set(itertools.chain(*conf.data.predictedOutputChannels))))
+    slurmArrayLength = str(
+        len(set(itertools.chain(*conf.data.predictedOutputChannels)))
+    )
     tcleanSlurm = get_optimal_taskNo_cpu_mem(conf)
     basename = "cube_tclean"
     filename = basename + ".sbatch"
     sbatchDict = {
-        'array': f"1-{slurmArrayLength}%{slurmArrayLength}",
-        'job-name': basename,
-        'cpus-per-task': tcleanSlurm['cpu'],
-        'mem': str(tcleanSlurm['mem']) + "GB",
-        'output': f"logs/{basename}-%A-%a.out",
-        'error': f"logs/{basename}-%A-%a.err",
-        'time': "20:00:00",
-        }
+        "array": f"1-{slurmArrayLength}%{slurmArrayLength}",
+        "job-name": basename,
+        "cpus-per-task": tcleanSlurm["cpu"],
+        "mem": str(tcleanSlurm["mem"]) + "GB",
+        "output": f"logs/{basename}-%A-%a.out",
+        "error": f"logs/{basename}-%A-%a.err",
+        "time": "20:00:00",
+    }
     if os.path.exists(basename + ".py"):
-        scriptPath =  basename + ".py"
+        scriptPath = basename + ".py"
     else:
-        scriptPath =  os.path.join(PATH_PACKAGE, basename + ".py")
-    command = conf.env.prefixSingularity + ' python3 ' + scriptPath + ' --slurmArrayTaskId ${SLURM_ARRAY_TASK_ID}'
+        scriptPath = os.path.join(PATH_PACKAGE, basename + ".py")
+    command = (
+        conf.env.prefixSingularity
+        + " python3 "
+        + scriptPath
+        + " --slurmArrayTaskId ${SLURM_ARRAY_TASK_ID}"
+    )
     write_sbtach_file(filename, command, conf, sbatchDict)
 
     # wsclean
@@ -262,20 +337,26 @@ def write_all_sbatch_files(conf):
     basename = "cube_wsclean"
     filename = basename + ".sbatch"
     sbatchDict = {
-        'ntasks': f"{conf.input.nchan}" if conf.input.nchan < conf.env.maxSimultaniousNodes else f"{conf.env.maxSimultaniousNodes}",
-        'nodes': f"{conf.input.nchan}" if conf.input.nchan < conf.env.maxSimultaniousNodes else f"{conf.env.maxSimultaniousNodes}",
-        'job-name': basename,
-        'cpus-per-task': f"{conf.input.threads}" if conf.input.threads < conf.env.tcleanMaxCpuCores else f"{conf.env.tcleanMaxCpuCores}",
-        'mem': str(tcleanSlurm['mem']) + "GB",
-        'output': f"logs/{basename}-%A-%a.out",
-        'error': f"logs/{basename}-%A-%a.err",
-        'time': "20:00:00",
-        }
+        "ntasks": f"{conf.input.nchan}"
+        if conf.input.nchan < conf.env.maxSimultaniousNodes
+        else f"{conf.env.maxSimultaniousNodes}",
+        "nodes": f"{conf.input.nchan}"
+        if conf.input.nchan < conf.env.maxSimultaniousNodes
+        else f"{conf.env.maxSimultaniousNodes}",
+        "job-name": basename,
+        "cpus-per-task": f"{conf.input.threads}"
+        if conf.input.threads < conf.env.tcleanMaxCpuCores
+        else f"{conf.env.tcleanMaxCpuCores}",
+        "mem": str(tcleanSlurm["mem"]) + "GB",
+        "output": f"logs/{basename}-%A-%a.out",
+        "error": f"logs/{basename}-%A-%a.err",
+        "time": "20:00:00",
+    }
     if os.path.exists(basename + ".py"):
-        scriptPath =  basename + ".py"
+        scriptPath = basename + ".py"
     else:
-        scriptPath =  os.path.join(PATH_PACKAGE, basename + ".py")
-    command = conf.env.prefixSingularity + ' python3 ' + scriptPath + ' --use_mpi'
+        scriptPath = os.path.join(PATH_PACKAGE, basename + ".py")
+    command = conf.env.prefixSingularity + " python3 " + scriptPath + " --use_mpi"
     write_sbtach_file(filename, command, conf, sbatchDict)
 
     # buildcube
@@ -286,19 +367,24 @@ def write_all_sbatch_files(conf):
     basename = "cube_buildcube"
     filename = basename + ".sbatch"
     sbatchDict = {
-            'array': f"1-{noOfArrayTasks}%{noOfArrayTasks}",
-            'job-name': basename,
-            'output': "logs/" + basename + "-%A-%a.out",
-            'error': "logs/" + basename + "-%A-%a.err",
-            'cpus-per-task': 2,
-            'mem': "50GB",
-            'time': "02:00:00",
-            }
+        "array": f"1-{noOfArrayTasks}%{noOfArrayTasks}",
+        "job-name": basename,
+        "output": "logs/" + basename + "-%A-%a.out",
+        "error": "logs/" + basename + "-%A-%a.err",
+        "cpus-per-task": 2,
+        "mem": "50GB",
+        "time": "02:00:00",
+    }
     if os.path.exists(basename + ".py"):
-        scriptPath =  basename + ".py"
+        scriptPath = basename + ".py"
     else:
-        scriptPath =  os.path.join(PATH_PACKAGE, basename + ".py")
-    command = conf.env.prefixSingularity + ' python3 ' + scriptPath + ' --slurmArrayTaskId ${SLURM_ARRAY_TASK_ID}'
+        scriptPath = os.path.join(PATH_PACKAGE, basename + ".py")
+    command = (
+        conf.env.prefixSingularity
+        + " python3 "
+        + scriptPath
+        + " --slurmArrayTaskId ${SLURM_ARRAY_TASK_ID}"
+    )
     write_sbtach_file(filename, command, conf, sbatchDict)
 
     # ior flagging
@@ -306,127 +392,129 @@ def write_all_sbatch_files(conf):
     filename = basename + ".sbatch"
     # TODO: calculate memory requirements better. Less magic numbers, put in config.
     sbatchDict = {
-            'array': "1-1%1",
-            'job-name': basename,
-            'output': "logs/" + basename + "-%A-%a.out",
-            'error': "logs/" + basename + "-%A-%a.err",
-            'cpus-per-task': conf.env.hdf5ConverterMaxCpuCores,
-            'mem': "230GB",
-            'time': "06:00:00",
-            }
+        "array": "1-1%1",
+        "job-name": basename,
+        "output": "logs/" + basename + "-%A-%a.out",
+        "error": "logs/" + basename + "-%A-%a.err",
+        "cpus-per-task": conf.env.hdf5ConverterMaxCpuCores,
+        "mem": "230GB",
+        "time": "06:00:00",
+    }
     if os.path.exists(basename + ".py"):
-        scriptPath =  basename + ".py"
+        scriptPath = basename + ".py"
     else:
-        scriptPath =  os.path.join(PATH_PACKAGE, basename + ".py")
-    command = conf.env.prefixSingularity + ' python3 ' + scriptPath
+        scriptPath = os.path.join(PATH_PACKAGE, basename + ".py")
+    command = conf.env.prefixSingularity + " python3 " + scriptPath
     write_sbtach_file(filename, command, conf, sbatchDict)
 
     # average map
     basename = "cube_average_map"
     filename = basename + ".sbatch"
     sbatchDict = {
-            'array': "1-1%1",
-            'job-name': basename,
-            'output': "logs/" + basename + "-%A-%a.out",
-            'error': "logs/" + basename + "-%A-%a.err",
-            'cpus-per-task': 1,
-            'mem': "100GB",
-            'time': "00:30:00",
-            }
+        "array": "1-1%1",
+        "job-name": basename,
+        "output": "logs/" + basename + "-%A-%a.out",
+        "error": "logs/" + basename + "-%A-%a.err",
+        "cpus-per-task": 1,
+        "mem": "100GB",
+        "time": "00:30:00",
+    }
     if os.path.exists(basename + ".py"):
-        scriptPath =  basename + ".py"
+        scriptPath = basename + ".py"
     else:
-        scriptPath =  os.path.join(PATH_PACKAGE, basename + ".py")
-    command = conf.env.prefixSingularity + ' python3 ' + scriptPath
+        scriptPath = os.path.join(PATH_PACKAGE, basename + ".py")
+    command = conf.env.prefixSingularity + " python3 " + scriptPath
     write_sbtach_file(filename, command, conf, sbatchDict)
 
     # cube_cleanup
     basename = "cube_cleanup"
     filename = basename + ".sbatch"
     sbatchDict = {
-            'array': "1-1%1",
-            'job-name': basename,
-            'output': "logs/" + basename + "-%A-%a.out",
-            'error': "logs/" + basename + "-%A-%a.err",
-            'cpus-per-task': 1,
-            'mem': "1GB",
-            'time': "01:00:00",
-            }
+        "array": "1-1%1",
+        "job-name": basename,
+        "output": "logs/" + basename + "-%A-%a.out",
+        "error": "logs/" + basename + "-%A-%a.err",
+        "cpus-per-task": 1,
+        "mem": "1GB",
+        "time": "01:00:00",
+    }
     if os.path.exists(basename + ".py"):
-        scriptPath =  basename + ".py"
+        scriptPath = basename + ".py"
     else:
-        scriptPath =  os.path.join(PATH_PACKAGE, basename + ".py")
-    command = conf.env.prefixSingularity + ' python3 ' + scriptPath
+        scriptPath = os.path.join(PATH_PACKAGE, basename + ".py")
+    command = conf.env.prefixSingularity + " python3 " + scriptPath
     write_sbtach_file(filename, command, conf, sbatchDict)
 
     # report
     basename = "cube_report"
     filename = basename + ".sbatch"
     sbatchDict = {
-            'array': "1-1%1",
-            'job-name': basename,
-            'output': "logs/" + basename + "-%A-%a.out",
-            'error': "logs/" + basename + "-%A-%a.err",
-            'cpus-per-task': 1,
-            'mem': "30GB",
-            'time': "00:30:00",
-            }
+        "array": "1-1%1",
+        "job-name": basename,
+        "output": "logs/" + basename + "-%A-%a.out",
+        "error": "logs/" + basename + "-%A-%a.err",
+        "cpus-per-task": 1,
+        "mem": "30GB",
+        "time": "00:30:00",
+    }
     if os.path.exists(basename + ".py"):
-        scriptPath =  basename + ".py"
+        scriptPath = basename + ".py"
     else:
-        scriptPath =  os.path.join(PATH_PACKAGE, basename + ".py")
-    command = conf.env.prefixSingularity + ' python3 ' + scriptPath
+        scriptPath = os.path.join(PATH_PACKAGE, basename + ".py")
+    command = conf.env.prefixSingularity + " python3 " + scriptPath
     write_sbtach_file(filename, command, conf, sbatchDict)
 
     # generate rmsy input data
     basename = "cube_generate_rmsy_input_data"
     filename = basename + ".sbatch"
     sbatchDict = {
-            'array': "1-1%1",
-            'job-name': basename,
-            'output': "logs/" + basename + "-%A-%a.out",
-            'error': "logs/" + basename + "-%A-%a.err",
-            'cpus-per-task': 1,
-            'mem': "100GB",
-            }
+        "array": "1-1%1",
+        "job-name": basename,
+        "output": "logs/" + basename + "-%A-%a.out",
+        "error": "logs/" + basename + "-%A-%a.err",
+        "cpus-per-task": 1,
+        "mem": "100GB",
+    }
     if os.path.exists(basename + ".py"):
-        scriptPath =  basename + ".py"
+        scriptPath = basename + ".py"
     else:
-        scriptPath =  os.path.join(PATH_PACKAGE, basename + ".py")
-    command = conf.env.prefixSingularity + ' python3 ' + scriptPath
+        scriptPath = os.path.join(PATH_PACKAGE, basename + ".py")
+    command = conf.env.prefixSingularity + " python3 " + scriptPath
     write_sbtach_file(filename, command, conf, sbatchDict)
 
     # do_rmsy
     basename = "cube_do_rmsy"
     filename = basename + ".sbatch"
     sbatchDict = {
-            'array': "1-1%1",
-            'job-name': basename,
-            'output': "logs/" + basename + "-%A-%a.out",
-            'error': "logs/" + basename + "-%A-%a.err",
-            'cpus-per-task': 1,
-            'mem': "10GB",
-            }
+        "array": "1-1%1",
+        "job-name": basename,
+        "output": "logs/" + basename + "-%A-%a.out",
+        "error": "logs/" + basename + "-%A-%a.err",
+        "cpus-per-task": 1,
+        "mem": "10GB",
+    }
     if os.path.exists(basename + ".py"):
-        scriptPath =  basename + ".py"
+        scriptPath = basename + ".py"
     else:
-        scriptPath =  os.path.join(PATH_PACKAGE, basename + ".py")
-    command = conf.env.prefixSingularity + ' python3 ' + scriptPath
+        scriptPath = os.path.join(PATH_PACKAGE, basename + ".py")
+    command = conf.env.prefixSingularity + " python3 " + scriptPath
     write_sbtach_file(filename, command, conf, sbatchDict)
 
+
 def copy_runscripts(conf):
-    '''
+    """
     Copies the runScripts to the local directory
-    '''
+    """
     for script in conf.input.runScripts:
         try:
             shutil.copyfile(os.path.join(PATH_PACKAGE, script), script)
         except shutil.SameFileError:
             pass
 
+
 def get_field(fieldListList, conf):
-    '''
-    '''
+    """
+    """
     if conf.input.field:
         # check if field is in any fieldList
         flatList = [item for sublist in fieldListList for item in sublist]
@@ -434,7 +522,7 @@ def get_field(fieldListList, conf):
             field = conf.input.field
         else:
             # TODO raise a proper error
-            error(f"Field \'{conf.input.field}\' is not in {conf.input.inputMS}.")
+            error(f"Field '{conf.input.field}' is not in {conf.input.inputMS}.")
             error(f"The following fields are found: {fieldListList}")
             sys.exit()
     elif len(fieldListList) > 1:
@@ -443,7 +531,9 @@ def get_field(fieldListList, conf):
             if fieldIntersection:
                 field = fieldIntersection.pop()
             else:
-                warning(f"Measurement field missmatch please check input data: {fieldListList}")
+                warning(
+                    f"Measurement field missmatch please check input data: {fieldListList}"
+                )
                 field = ""
                 break
     else:
@@ -451,18 +541,18 @@ def get_field(fieldListList, conf):
     info(f"Setting field to: {field}")
     return field
 
-@click.command(context_settings=dict(
-    ignore_unknown_options=True,
-    allow_extra_args=True,
-))
+
+@click.command(
+    context_settings=dict(ignore_unknown_options=True, allow_extra_args=True,)
+)
 @click.pass_context
 @main_timer
 def main(ctx):
-    '''
+    """
     CAUTION: This method must be seen in combination with setup_buildcube_wrapper.py
     TODO: I made click super generic which is nice for development but we may
     want to change this for production.
-    '''
+    """
     if "--createConfig" in ctx.args:
         # If not deleted this key would appear in the config file.
         # get the click args in dot dotation
@@ -470,10 +560,13 @@ def main(ctx):
         info(f"Scripts arguments: {conf}")
         write_user_config_input(conf)
         # copy config template into local directory
-#        TODO: make the user chose the file. if conf.input.configFile:
-#            shutil.copy2(os.path.join(FILEPATH_CONFIG_USER, conf.input.configFile)
+        #        TODO: make the user chose the file. if conf.input.configFile:
+        #            shutil.copy2(os.path.join(FILEPATH_CONFIG_USER, conf.input.configFile)
         try:
-            shutil.copy2(os.path.join(PATH_PACKAGE, FILEPATH_CONFIG_TEMPLATE_ORIGINAL), FILEPATH_CONFIG_TEMPLATE)
+            shutil.copy2(
+                os.path.join(PATH_PACKAGE, FILEPATH_CONFIG_TEMPLATE_ORIGINAL),
+                FILEPATH_CONFIG_TEMPLATE,
+            )
         except shutil.SameFileError:
             # TODO: check if this really works when packed in a python package
             pass
@@ -482,47 +575,66 @@ def main(ctx):
     if "--createScripts" in ctx.args:
         # data: values derived from the measurement set like valid channels
         data = {}
-        conf = get_config_in_dot_notation(templateFilename=FILEPATH_CONFIG_TEMPLATE, configFilename=FILEPATH_CONFIG_USER)
+        conf = get_config_in_dot_notation(
+            templateFilename=FILEPATH_CONFIG_TEMPLATE,
+            configFilename=FILEPATH_CONFIG_USER,
+        )
 
         # iterate ofer multible ms. This is necessary to feed tclean with multiple ms at once.
-        data['workingDirectory'] = os.getcwd()
-        data['predictedOutputChannels'] = []
-        data['fields'] = []
-        data['field'] = ""
+        data["workingDirectory"] = os.getcwd()
+        data["predictedOutputChannels"] = []
+        data["fields"] = []
+        data["field"] = ""
         for msIdx, inputMS in enumerate(conf.input.inputMS):
             info(SEPERATOR)
-            data['predictedOutputChannels'].append(get_unflagged_channelList(conf, msIdx))
-            data['fields'].append(get_fields(conf, msIdx))
-        data['field'] = get_field(data['fields'], conf)
+            data["predictedOutputChannels"].append(
+                get_unflagged_channelList(conf, msIdx)
+            )
+            data["fields"].append(get_fields(conf, msIdx))
+        data["field"] = get_field(data["fields"], conf)
         update_user_config_data(data)
         # reload conf after data got appended to user conf
-        conf = get_config_in_dot_notation(templateFilename=FILEPATH_CONFIG_TEMPLATE, configFilename=FILEPATH_CONFIG_USER)
+        conf = get_config_in_dot_notation(
+            templateFilename=FILEPATH_CONFIG_TEMPLATE,
+            configFilename=FILEPATH_CONFIG_USER,
+        )
 
-        #if conf.input.copyRunscripts:
-        #if "--copyScripts" in ctx.args:
+        # if conf.input.copyRunscripts:
+        # if "--copyScripts" in ctx.args:
         #    copy_runscripts(conf)
 
-        #write_all_sbatch_files(conf)
+        # write_all_sbatch_files(conf)
 
         return None  # ugly but maybe best solution, because of wrapper
 
     if "--start" in ctx.args:
-        conf = get_config_in_dot_notation(templateFilename=FILEPATH_CONFIG_TEMPLATE, configFilename=FILEPATH_CONFIG_USER)
+        conf = get_config_in_dot_notation(
+            templateFilename=FILEPATH_CONFIG_TEMPLATE,
+            configFilename=FILEPATH_CONFIG_USER,
+        )
         create_directories(conf)
         args = DotMap(get_dict_from_click_args(ctx.args))
-        firstRunScript = conf.input.runScripts[0].replace('.py', '.sbatch')
-        command = f"SLURMID=$(sbatch {firstRunScript} | cut -d ' ' -f4) && echo SLURMID: "
+        firstRunScript = conf.input.runScripts[0].replace(".py", ".sbatch")
+        command = (
+            f"SLURMID=$(sbatch {firstRunScript} | cut -d ' ' -f4) && echo SLURMID: "
+        )
         for runScript in conf.input.runScripts[1:]:
             sbatchScript = runScript.replace(".py", ".sbatch")
             command += f"$SLURMID;SLURMID=$(sbatch --dependency=afterany:$SLURMID {sbatchScript} | cut -d ' ' -f4) && echo "
         command += "$SLURMID && echo Slurm jobs submitted!"
         info(f"Slurm command: {command}")
-        sbatchResult = subprocess.run(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True, shell=True)
+        sbatchResult = subprocess.run(
+            command,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            universal_newlines=True,
+            shell=True,
+        )
         sbatchResultStd = sbatchResult.stdout.replace("\n", " ")
         info(sbatchResultStd)
         # parse the slurm job ID from sbatchResult
-        slurmIDList = [ int(num) for num in sbatchResultStd.split() if num.isdigit() ]
-        update_user_config_data({'slurmIDList': slurmIDList})
+        slurmIDList = [int(num) for num in sbatchResultStd.split() if num.isdigit()]
+        update_user_config_data({"slurmIDList": slurmIDList})
         if sbatchResult.stderr:
             sbatchResultStderrList = sbatchResult.stderr.split("\n")
             for sbatchResultStderr in sbatchResultStderrList:
@@ -530,12 +642,14 @@ def main(ctx):
         return None
 
     if "--cancel" in ctx.args or "--kill" in ctx.args:
-        conf = get_config_in_dot_notation(templateFilename=FILEPATH_CONFIG_TEMPLATE, configFilename=FILEPATH_CONFIG_USER)
+        conf = get_config_in_dot_notation(
+            templateFilename=FILEPATH_CONFIG_TEMPLATE,
+            configFilename=FILEPATH_CONFIG_USER,
+        )
         command = f'scancel {" ".join(map(str,conf.data.slurmIDList))}'
         run_command_with_logging(command)
         return None
 
 
-
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/frocc/setup_buildcube_wrapper.py
+++ b/frocc/setup_buildcube_wrapper.py
@@ -33,19 +33,18 @@ from frocc.setup_buildcube import write_all_sbatch_files, copy_runscripts
 
 # TODO: put this in default_config.* at a later stage
 #PREFIX_SINGULARITY = "srun --qos qos-interactive --nodes=1 --ntasks=1 --time=10 --mem=20GB --partition=Main singularity exec /idia/software/containers/casa-6.simg python3 $HOME/.local/bin/setup_buildcube "
-PREFIX_SRUN = "srun -N 1 --preserve-env --mem 20G --ntasks-per-node 1 --cpus-per-task 2 --time 00:30:00 --pty"
+PREFIX_SRUN = "srun -N 1 --export=ALL --preserve-env --mem 20G --ntasks-per-node 1 --cpus-per-task 2 --time 00:30:00 --pty"
 #PREFIX_SINGULARITY = "srun --qos qos-interactive -N 1 --mem 20G --ntasks-per-node 1 --cpus-per-task 4 --time 1:00:00 --pty singularity exec /data/exp_soft/containers/casa-6.simg"
 #COMMAND = "python3 " + expanduser('~') + "/.local/bin/setup_buildcube"
 #COMMAND = "setup_buildcube"
 
 PATH_HOME = expanduser("~") + "/"
 
-PATH_QUICKFIX = f"{PATH_HOME}/bin:{PATH_HOME}.local/bin:{PATH_HOME}local/bin:/opt/anaconda3/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin:/opt/slurm/bin:/idia/software/pipelines/jordan-dev/processMeerKAT:{PATH_HOME}.local/bin:/idia/software/pipelines/jordan-dev/processMeerKAT/:{PATH_HOME}.fzf/bin:/users/lennart/software"
-
-PYTHONPATH_QUICKFIX = f"{PATH_HOME}.local/lib/python3.7/site-packages/:/idia/software/pipelines/jordan-dev/processMeerKAT:{PATH_HOME}.local/lib/python3.7/site-packages/:/idia/software/pipelines/jordan-dev/processMeerKAT:{PATH_HOME}python-tools:/idia/software/pipelines/jordan-dev/processMeerKAT/"
-
-os.environ['PATH'] = ":".join([os.environ.get('PATH'), PATH_QUICKFIX])
-os.environ['PYTHONPATH'] = ":".join([os.environ.get('PYTHONPATH'), PYTHONPATH_QUICKFIX])
+# A Thomson: Commenting out hard-coded paths.
+# PATH_QUICKFIX = f"{PATH_HOME}/bin:{PATH_HOME}.local/bin:{PATH_HOME}local/bin:/opt/anaconda3/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin:/opt/slurm/bin:/idia/software/pipelines/jordan-dev/processMeerKAT:{PATH_HOME}.local/bin:/idia/software/pipelines/jordan-dev/processMeerKAT/:{PATH_HOME}.fzf/bin:/users/lennart/software"
+# PYTHONPATH_QUICKFIX = f"{PATH_HOME}.local/lib/python3.7/site-packages/:/idia/software/pipelines/jordan-dev/processMeerKAT:{PATH_HOME}.local/lib/python3.7/site-packages/:/idia/software/pipelines/jordan-dev/processMeerKAT:{PATH_HOME}python-tools:/idia/software/pipelines/jordan-dev/processMeerKAT/"
+# os.environ['PATH'] = ":".join([os.environ.get('PATH'), PATH_QUICKFIX])
+# os.environ['PYTHONPATH'] = ":".join([os.environ.get('PYTHONPATH'), PYTHONPATH_QUICKFIX])
 
 
 @click.command(context_settings=dict(
@@ -95,9 +94,10 @@ def main(ctx):
         print("!!!!!!!!")
         if not conf.data:
             commandList = PREFIX_SRUN.split(" ") + conf.env.prefixSingularity.split(" ") + conf.env.commandSingularity.replace("${HOME}", PATH_HOME).split(" ") + ctx.args
+            commandList = [i for i in commandList if i]
             print(commandList)
             logger.info(f"Command: {' '.join(commandList)}")
-            subprocess.run(commandList, env={"SINGULARITYENV_APPEND_PATH": os.environ["PATH"], "PATH": os.environ["PATH"], "PYTHONPATH": os.environ["PYTHONPATH"]})
+            subprocess.run(commandList, env={"SINGULARITYENV_APPEND_PATH": os.environ["PATH"], "PATH": os.environ["PATH"], "PYTHONPATH": os.environ["PYTHONPATH"], "HOME": os.environ["HOME"]})
         else:
             warning(f"Found [data] section in {FILEPATH_CONFIG_USER}. Using those values! To re-calculate them delete the [data] section and re-run `--createScripts`.")
 

--- a/tmp/setup_buildcube.py
+++ b/tmp/setup_buildcube.py
@@ -1,7 +1,4 @@
-<<<<<<< Updated upstream
-#!python3
-=======
->>>>>>> Stashed changes
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 import sys
 import logging
@@ -18,14 +15,8 @@ from logging import info, error, warning
 from frocc.lhelpers import get_dict_from_click_args, DotMap, get_config_in_dot_notation, main_timer, write_sbtach_file, get_firstFreq, get_basename_from_path, get_optimal_taskNo_cpu_mem, SEPERATOR
 import frocc
 
-<<<<<<< Updated upstream
-os.environ['LC_ALL'] = "C.UTF-8"
-os.environ['LANG'] = "C.UTF-8"
-
-=======
 os.environ['LC_ALL'] = "C-UTF-8"
 os.environ['LANG'] = "C-UTF-8"
->>>>>>> Stashed changes
 # need to be instaled in container. Right now linkt with $PYTHONPATH
 import click
 
@@ -364,7 +355,7 @@ def main(ctx):
         command = f"SLURMID=$(sbatch {firstRunScript} | cut -d ' ' -f4) && "
         for runScript in conf.env.runScripts[1:]:
             sbatchScript = runScript.replace(".py", ".sbatch")
-            command += f"echo SLURMID: $SLURMID;SLURMID=$(sbatch --dependency=afterany:$SLURMID {sbatchScript} | cut -d ' ' -f4) && "
+            command += f"echo SLURMID: $SLURMID;SLURMID=$(sbatch --dependency=afterok:$SLURMID {sbatchScript} | cut -d ' ' -f4) && "
         command += "Slurm jobs submitted!"
         subprocess.run(command, shell=True)
         return None


### PR DESCRIPTION
New feature - adding wsclean as an imager!

I've added a wrapper function which exposes _all_ the options of wsclean. I've added some options to the default config, but not all are really necessary. Where appropriate, the common params between tclean and wsclean are used. Its important to note, though, that useful defaults for tclean may not be appropriate for wsclean and vice-versa.

For this to work, it requires a separate installation of wsclean and its libraries. Also, to be compatible with IDIA-pipeline MSs v3.0 of wsclean is needed. 

wsclean does it's own parallelisation using wsclean-mp and some internal threading. This means that when using wsclean, the split stage is not needed. The advantage of wsclean is that it can do joint-convolution, using the full bandwidth when deconvolving.

This PR builds on the updates of #4 - so we may want to clear those changes first before merging this one.